### PR TITLE
Use complete string for filtering.

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -248,7 +248,7 @@ func (n *Nuke) Filter(item *Item) {
 	}
 
 	for _, filter := range filters {
-		if strings.HasPrefix(item.Resource.String(), filter) {
+		if filter == item.Resource.String() {
 			item.State = ItemStateFiltered
 			item.Reason = "filtered by config"
 			return


### PR DESCRIPTION
@rebuy-de/prp-aws-nuke The fix for the filter actually screwed it up.
e.g. filter for `Jenkins` also filtered `jenkins-check-user`.

**Please review!**