### PR TITLE
Revert "Fix Variable name"

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -15,9 +15,9 @@ func Scan(sess *session.Session) *Scanner {
 	items := make(chan *Item, 100)
 
 	go func() {
-		listeners := resources.GetListers(sess)
+		listers := resources.GetListers(sess)
 
-		for _, lister := range listeners {
+		for _, lister := range listers {
 			var r []resources.Resource
 			r, err = lister()
 			if err != nil {


### PR DESCRIPTION
Reverts rebuy-de/aws-nuke#26

Because they actually are "listers" :wink: 

@rebuy-de/it-platform 