### PR TITLE
improve resilience

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -211,8 +211,8 @@ func (n *Nuke) Scan() error {
 
 	for _, region := range n.Config.Regions {
 		sess := n.sessions[region]
-		scanner := Scan(sess)
-		for item := range scanner.Items {
+		items := Scan(sess)
+		for item := range items {
 			if !n.Parameters.WantsTarget(item.Service) {
 				continue
 			}
@@ -221,12 +221,8 @@ func (n *Nuke) Scan() error {
 			n.Filter(item)
 			item.Print()
 		}
-		if scanner.Error != nil {
-			fmt.Printf("Scanner found an error %s \n", scanner.Error)
-			return scanner.Error
-		}
-
 	}
+
 	fmt.Printf("Scan complete: %d total, %d nukeable, %d filtered.\n\n",
 		queue.CountTotal(), queue.Count(ItemStateNew), queue.Count(ItemStateFiltered))
 

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rebuy-de/aws-nuke/resources"
+)
+
+func TestSafeLister(t *testing.T) {
+	nilLister := func() ([]resources.Resource, error) {
+		var ptr *string = nil
+		_ = *ptr
+
+		return nil, nil
+	}
+
+	_, err := safeLister(nilLister)
+	if !strings.Contains(err.Error(), "runtime error: invalid memory address or nil pointer dereference") {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This improves the error handling. If a lister should fail *aws-nuke* will continue. It would look like this:

```
eu-west-1 - CloudFormationStack - 'acm-certificates' - filtered by config

=============

Listing with resources.ResourceLister failed:

runtime error: invalid memory address or nil pointer dereference

goroutine 27 [running]:
runtime/debug.Stack(0xe3fcc0, 0xe24f00, 0x17ffe60)
	/home/sven/Data/Applications/golang/src/runtime/debug/stack.go:24 +0xa7
github.com/rebuy-de/aws-nuke/cmd.safeLister.func1(0xc4200fff18)
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/cmd/scan.go:49 +0x75
panic(0xe24f00, 0x17ffe60)
	/home/sven/Data/Applications/golang/src/runtime/panic.go:491 +0x283
github.com/rebuy-de/aws-nuke/resources.(*EC2Nuke).ListInstances(0xc42000e110, 0xc4201ce300, 0xc4ad80, 0xc4200ffec0, 0xc4200ffec8, 0xc4200ffec0)
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/resources/ec2-instances.go:17 +0x31
github.com/rebuy-de/aws-nuke/resources.(*EC2Nuke).ListInstances-fm(0xc400000008, 0xffbb90, 0xc4200fff18, 0x0, 0x0)
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/resources/listers.go:55 +0x2a
github.com/rebuy-de/aws-nuke/cmd.safeLister(0xc4203f2540, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/cmd/scan.go:53 +0x7e
github.com/rebuy-de/aws-nuke/cmd.Scan.func1(0xc420001680, 0xc4201787e0)
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/cmd/scan.go:18 +0x25a
created by github.com/rebuy-de/aws-nuke/cmd.Scan
	/home/sven/Data/Projects/src/github.com/rebuy-de/aws-nuke/cmd/scan.go:14 +0x67


Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.

=============

eu-west-1 - EC2KeyPair - 'sven.notebook' - filtered by config
eu-west-1 - EC2SpotFleetRequest - 'sfr-aadb907a-6586-439f-9865-8a489f24994b' - already cancelled
eu-west-1 - EC2SpotFleetRequest - 'sfr-b70670f1-8c23-43fe-84e1-f17ae495f7d2' - already cancelled
```

@rebuy-de/prp-aws-nuke Please review.