### PR TITLE
Consistent capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ eu-west-1 - EC2SecurityGroup - 'sg-f20f958a' - would remove
 eu-west-1 - EC2Subnet - 'subnet-154d844e' - would remove
 eu-west-1 - EC2Volume - 'vol-0ddfb15461a00c3e2' - would remove
 eu-west-1 - EC2Vpc - 'vpc-c6159fa1' - would remove
-eu-west-1 - IamUserAccessKeys - 'my-user -> ABCDEFGHIJKLMNOPQRST' - would remove
-eu-west-1 - IamUserPolicyAttachment - 'my-user -> AdministratorAccess' - would remove
-eu-west-1 - IamUser - 'my-user' - would remove
+eu-west-1 - IAMUserAccessKey - 'my-user -> ABCDEFGHIJKLMNOPQRST' - would remove
+eu-west-1 - IAMUserPolicyAttachment - 'my-user -> AdministratorAccess' - would remove
+eu-west-1 - IAMUser - 'my-user' - would remove
 Scan complete: 13 total, 11 nukeable, 2 filtered.
 
 Would delete these resources. Provide --no-dry-run to actually destroy resources.
@@ -116,11 +116,11 @@ account-blacklist:
 accounts:
   "000000000000": # aws-nuke-example
     filters:
-      IamUser:
+      IAMUser:
       - "my-user"
-      IamUserPolicyAttachment:
+      IAMUserPolicyAttachment:
       - "my-user -> AdministratorAccess"
-      IamUserAccessKeys:
+      IAMUserAccessKey:
       - "my-user -> ABCDEFGHIJKLMNOPQRST"
 ```
 
@@ -142,9 +142,9 @@ eu-west-1 - EC2SecurityGroup - 'sg-f20f958a' - would remove
 eu-west-1 - EC2Subnet - 'subnet-154d844e' - would remove
 eu-west-1 - EC2Volume - 'vol-0ddfb15461a00c3e2' - would remove
 eu-west-1 - EC2Vpc - 'vpc-c6159fa1' - would remove
-eu-west-1 - IamUserAccessKeys - 'my-user -> ABCDEFGHIJKLMNOPQRST' - filtered by config
-eu-west-1 - IamUserPolicyAttachment - 'my-user -> AdministratorAccess' - filtered by config
-eu-west-1 - IamUser - 'my-user' - filtered by config
+eu-west-1 - IAMUserAccessKey - 'my-user -> ABCDEFGHIJKLMNOPQRST' - filtered by config
+eu-west-1 - IAMUserPolicyAttachment - 'my-user -> AdministratorAccess' - filtered by config
+eu-west-1 - IAMUser - 'my-user' - filtered by config
 Scan complete: 13 total, 8 nukeable, 5 filtered.
 
 Do you really want to nuke these resources on the account with the ID 000000000000 and the alias 'aws-nuke-example'?

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -60,10 +60,10 @@ func TestLoadExampleConfig(t *testing.T) {
 		Accounts: map[string]NukeConfigAccount{
 			"555133742": NukeConfigAccount{
 				Filters: map[string][]string{
-					"IamRole": []string{
+					"IAMRole": []string{
 						"uber.admin",
 					},
-					"IamRolePolicyAttachment": []string{
+					"IAMRolePolicyAttachment": []string{
 						"uber.admin -> AdministratorAccess",
 					},
 				},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func NewRootCommand() *cobra.Command {
 		"AWS secret-access-key")
 	command.PersistentFlags().StringSliceVarP(
 		&params.Targets, "target", "t", []string{},
-		"limit nuking to certain resource types (eg IamServerCertificate)")
+		"limit nuking to certain resource types (eg IAMServerCertificate)")
 	command.PersistentFlags().BoolVar(
 		&params.NoDryRun, "no-dry-run", false,
 		"actualy delete found resources")

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -7,7 +7,7 @@ account-blacklist:
 accounts:
   555133742:
     filters:
-      IamRole:
+      IAMRole:
       - "uber.admin"
-      IamRolePolicyAttachment:
+      IAMRolePolicyAttachment:
       - "uber.admin -> AdministratorAccess"

--- a/resources/ecr-repository.go
+++ b/resources/ecr-repository.go
@@ -7,13 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
-type ECRrepository struct {
+type ECRRepository struct {
 	svc  *ecr.ECR
 	name *string
 }
 
 func (n *ECRNuke) ListRepos() ([]Resource, error) {
-
 	var params *ecr.DescribeRepositoriesInput
 	var resp *ecr.DescribeRepositoriesOutput
 	var resources []Resource
@@ -43,7 +42,7 @@ func (n *ECRNuke) ListRepos() ([]Resource, error) {
 			return nil, err
 		}
 		for _, repository := range resp.Repositories {
-			resources = append(resources, &ECRrepository{
+			resources = append(resources, &ECRRepository{
 				svc:  n.Service,
 				name: repository.RepositoryName,
 			})
@@ -53,11 +52,11 @@ func (n *ECRNuke) ListRepos() ([]Resource, error) {
 	return resources, nil
 }
 
-func (r *ECRrepository) Filter() error {
+func (r *ECRRepository) Filter() error {
 	return nil
 }
 
-func (r *ECRrepository) Remove() error {
+func (r *ECRRepository) Remove() error {
 
 	params := &ecr.DeleteRepositoryInput{
 		RepositoryName: r.name,
@@ -67,6 +66,6 @@ func (r *ECRrepository) Remove() error {
 	return err
 }
 
-func (r *ECRrepository) String() string {
+func (r *ECRRepository) String() string {
 	return fmt.Sprintf("Repository: %s", *r.name)
 }

--- a/resources/iam-group-policy-attachments.go
+++ b/resources/iam-group-policy-attachments.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamGroupPolicyAttachment struct {
+type IAMGroupPolicyAttachment struct {
 	svc        *iam.IAM
 	policyArn  string
 	policyName string
 	roleName   string
 }
 
-func (n *IamNuke) ListGroupPolicyAttachments() ([]Resource, error) {
+func (n *IAMNuke) ListGroupPolicyAttachments() ([]Resource, error) {
 	resp, err := n.Service.ListGroups(nil)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (n *IamNuke) ListGroupPolicyAttachments() ([]Resource, error) {
 		}
 
 		for _, pol := range resp.AttachedPolicies {
-			resources = append(resources, &IamGroupPolicyAttachment{
+			resources = append(resources, &IAMGroupPolicyAttachment{
 				svc:        n.Service,
 				policyArn:  *pol.PolicyArn,
 				policyName: *pol.PolicyName,
@@ -42,7 +42,7 @@ func (n *IamNuke) ListGroupPolicyAttachments() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamGroupPolicyAttachment) Remove() error {
+func (e *IAMGroupPolicyAttachment) Remove() error {
 	_, err := e.svc.DetachGroupPolicy(
 		&iam.DetachGroupPolicyInput{
 			PolicyArn: &e.policyArn,
@@ -55,6 +55,6 @@ func (e *IamGroupPolicyAttachment) Remove() error {
 	return nil
 }
 
-func (e *IamGroupPolicyAttachment) String() string {
+func (e *IAMGroupPolicyAttachment) String() string {
 	return fmt.Sprintf("%s -> %s", e.roleName, e.policyName)
 }

--- a/resources/iam-groups.go
+++ b/resources/iam-groups.go
@@ -2,12 +2,12 @@ package resources
 
 import "github.com/aws/aws-sdk-go/service/iam"
 
-type IamGroup struct {
+type IAMGroup struct {
 	svc  *iam.IAM
 	name string
 }
 
-func (n *IamNuke) ListGroups() ([]Resource, error) {
+func (n *IAMNuke) ListGroups() ([]Resource, error) {
 	resp, err := n.Service.ListGroups(nil)
 	if err != nil {
 		return nil, err
@@ -15,7 +15,7 @@ func (n *IamNuke) ListGroups() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.Groups {
-		resources = append(resources, &IamGroup{
+		resources = append(resources, &IAMGroup{
 			svc:  n.Service,
 			name: *out.GroupName,
 		})
@@ -24,7 +24,7 @@ func (n *IamNuke) ListGroups() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamGroup) Remove() error {
+func (e *IAMGroup) Remove() error {
 	_, err := e.svc.DeleteGroup(&iam.DeleteGroupInput{
 		GroupName: &e.name,
 	})
@@ -35,6 +35,6 @@ func (e *IamGroup) Remove() error {
 	return nil
 }
 
-func (e *IamGroup) String() string {
+func (e *IAMGroup) String() string {
 	return e.name
 }

--- a/resources/iam-instance-profile-roles.go
+++ b/resources/iam-instance-profile-roles.go
@@ -6,13 +6,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamInstanceProfileRole struct {
+type IAMInstanceProfileRole struct {
 	svc     *iam.IAM
 	role    string
 	profile string
 }
 
-func (n *IamNuke) ListInstanceProfileRoles() ([]Resource, error) {
+func (n *IAMNuke) ListInstanceProfileRoles() ([]Resource, error) {
 	resp, err := n.Service.ListInstanceProfiles(nil)
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func (n *IamNuke) ListInstanceProfileRoles() ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, out := range resp.InstanceProfiles {
 		for _, role := range out.Roles {
-			resources = append(resources, &IamInstanceProfileRole{
+			resources = append(resources, &IAMInstanceProfileRole{
 				svc:     n.Service,
 				profile: *out.InstanceProfileName,
 				role:    *role.RoleName,
@@ -32,7 +32,7 @@ func (n *IamNuke) ListInstanceProfileRoles() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamInstanceProfileRole) Remove() error {
+func (e *IAMInstanceProfileRole) Remove() error {
 	_, err := e.svc.RemoveRoleFromInstanceProfile(
 		&iam.RemoveRoleFromInstanceProfileInput{
 			InstanceProfileName: &e.profile,
@@ -45,6 +45,6 @@ func (e *IamInstanceProfileRole) Remove() error {
 	return nil
 }
 
-func (e *IamInstanceProfileRole) String() string {
+func (e *IAMInstanceProfileRole) String() string {
 	return fmt.Sprintf("%s -> %s", e.profile, e.role)
 }

--- a/resources/iam-instance-profiles.go
+++ b/resources/iam-instance-profiles.go
@@ -2,12 +2,12 @@ package resources
 
 import "github.com/aws/aws-sdk-go/service/iam"
 
-type IamInstanceProfile struct {
+type IAMInstanceProfile struct {
 	svc  *iam.IAM
 	name string
 }
 
-func (n *IamNuke) ListInstanceProfiles() ([]Resource, error) {
+func (n *IAMNuke) ListInstanceProfiles() ([]Resource, error) {
 	resp, err := n.Service.ListInstanceProfiles(nil)
 	if err != nil {
 		return nil, err
@@ -15,7 +15,7 @@ func (n *IamNuke) ListInstanceProfiles() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.InstanceProfiles {
-		resources = append(resources, &IamInstanceProfile{
+		resources = append(resources, &IAMInstanceProfile{
 			svc:  n.Service,
 			name: *out.InstanceProfileName,
 		})
@@ -24,7 +24,7 @@ func (n *IamNuke) ListInstanceProfiles() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamInstanceProfile) Remove() error {
+func (e *IAMInstanceProfile) Remove() error {
 	_, err := e.svc.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
 		InstanceProfileName: &e.name,
 	})
@@ -35,6 +35,6 @@ func (e *IamInstanceProfile) Remove() error {
 	return nil
 }
 
-func (e *IamInstanceProfile) String() string {
+func (e *IAMInstanceProfile) String() string {
 	return e.name
 }

--- a/resources/iam-list-user-group-attachments.go
+++ b/resources/iam-list-user-group-attachments.go
@@ -6,13 +6,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamUserGroupAttachment struct {
+type IAMUserGroupAttachment struct {
 	svc       *iam.IAM
 	groupName string
 	userName  string
 }
 
-func (n *IamNuke) ListUserGroupAttachments() ([]Resource, error) {
+func (n *IAMNuke) ListUserGroupAttachments() ([]Resource, error) {
 	resp, err := n.Service.ListUsers(nil)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (n *IamNuke) ListUserGroupAttachments() ([]Resource, error) {
 		}
 
 		for _, grp := range resp.Groups {
-			resources = append(resources, &IamUserGroupAttachment{
+			resources = append(resources, &IAMUserGroupAttachment{
 				svc:       n.Service,
 				groupName: *grp.GroupName,
 				userName:  *role.UserName,
@@ -40,7 +40,7 @@ func (n *IamNuke) ListUserGroupAttachments() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamUserGroupAttachment) Remove() error {
+func (e *IAMUserGroupAttachment) Remove() error {
 	_, err := e.svc.RemoveUserFromGroup(
 		&iam.RemoveUserFromGroupInput{
 			GroupName: &e.groupName,
@@ -53,6 +53,6 @@ func (e *IamUserGroupAttachment) Remove() error {
 	return nil
 }
 
-func (e *IamUserGroupAttachment) String() string {
+func (e *IAMUserGroupAttachment) String() string {
 	return fmt.Sprintf("%s -> %s", e.userName, e.groupName)
 }

--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -5,12 +5,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamPolicy struct {
+type IAMPolicy struct {
 	svc *iam.IAM
 	arn string
 }
 
-func (n *IamNuke) ListPolicies() ([]Resource, error) {
+func (n *IAMNuke) ListPolicies() ([]Resource, error) {
 	resp, err := n.Service.ListPolicies(&iam.ListPoliciesInput{
 		Scope: aws.String("Local"),
 	})
@@ -20,7 +20,7 @@ func (n *IamNuke) ListPolicies() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.Policies {
-		resources = append(resources, &IamPolicy{
+		resources = append(resources, &IAMPolicy{
 			svc: n.Service,
 			arn: *out.Arn,
 		})
@@ -29,7 +29,7 @@ func (n *IamNuke) ListPolicies() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamPolicy) Remove() error {
+func (e *IAMPolicy) Remove() error {
 	resp, err := e.svc.ListPolicyVersions(&iam.ListPolicyVersionsInput{
 		PolicyArn: &e.arn,
 	})
@@ -58,6 +58,6 @@ func (e *IamPolicy) Remove() error {
 	return nil
 }
 
-func (e *IamPolicy) String() string {
+func (e *IAMPolicy) String() string {
 	return e.arn
 }

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamRolePolicyAttachment struct {
+type IAMRolePolicyAttachment struct {
 	svc        *iam.IAM
 	policyArn  string
 	policyName string
 	roleName   string
 }
 
-func (n *IamNuke) ListRolePolicyAttachments() ([]Resource, error) {
+func (n *IAMNuke) ListRolePolicyAttachments() ([]Resource, error) {
 	resp, err := n.Service.ListRoles(nil)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func (n *IamNuke) ListRolePolicyAttachments() ([]Resource, error) {
 		}
 
 		for _, pol := range resp.AttachedPolicies {
-			resources = append(resources, &IamRolePolicyAttachment{
+			resources = append(resources, &IAMRolePolicyAttachment{
 				svc:        n.Service,
 				policyArn:  *pol.PolicyArn,
 				policyName: *pol.PolicyName,
@@ -43,14 +43,14 @@ func (n *IamNuke) ListRolePolicyAttachments() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamRolePolicyAttachment) Filter() error {
+func (e *IAMRolePolicyAttachment) Filter() error {
 	if strings.HasPrefix(e.policyArn, "arn:aws:iam::aws:policy/aws-service-role/") {
 		return fmt.Errorf("cannot detach from service roles")
 	}
 	return nil
 }
 
-func (e *IamRolePolicyAttachment) Remove() error {
+func (e *IAMRolePolicyAttachment) Remove() error {
 	_, err := e.svc.DetachRolePolicy(
 		&iam.DetachRolePolicyInput{
 			PolicyArn: &e.policyArn,
@@ -63,6 +63,6 @@ func (e *IamRolePolicyAttachment) Remove() error {
 	return nil
 }
 
-func (e *IamRolePolicyAttachment) String() string {
+func (e *IAMRolePolicyAttachment) String() string {
 	return fmt.Sprintf("%s -> %s", e.roleName, e.policyName)
 }

--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -7,13 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamRole struct {
+type IAMRole struct {
 	svc  *iam.IAM
 	name string
 	path string
 }
 
-func (n *IamNuke) ListRoles() ([]Resource, error) {
+func (n *IAMNuke) ListRoles() ([]Resource, error) {
 	resp, err := n.Service.ListRoles(nil)
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func (n *IamNuke) ListRoles() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.Roles {
-		resources = append(resources, &IamRole{
+		resources = append(resources, &IAMRole{
 			svc:  n.Service,
 			name: *out.RoleName,
 			path: *out.Path,
@@ -31,14 +31,14 @@ func (n *IamNuke) ListRoles() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamRole) Filter() error {
+func (e *IAMRole) Filter() error {
 	if strings.HasPrefix(e.path, "/aws-service-role/") {
 		return fmt.Errorf("cannot delete service roles")
 	}
 	return nil
 }
 
-func (e *IamRole) Remove() error {
+func (e *IAMRole) Remove() error {
 	_, err := e.svc.DeleteRole(&iam.DeleteRoleInput{
 		RoleName: &e.name,
 	})
@@ -49,6 +49,6 @@ func (e *IamRole) Remove() error {
 	return nil
 }
 
-func (e *IamRole) String() string {
+func (e *IAMRole) String() string {
 	return e.name
 }

--- a/resources/iam-server-certificate.go
+++ b/resources/iam-server-certificate.go
@@ -2,12 +2,12 @@ package resources
 
 import "github.com/aws/aws-sdk-go/service/iam"
 
-type IamServerCertificate struct {
+type IAMServerCertificate struct {
 	svc  *iam.IAM
 	name string
 }
 
-func (n *IamNuke) ListServerCertificates() ([]Resource, error) {
+func (n *IAMNuke) ListServerCertificates() ([]Resource, error) {
 	resp, err := n.Service.ListServerCertificates(nil)
 	if err != nil {
 		return nil, err
@@ -15,7 +15,7 @@ func (n *IamNuke) ListServerCertificates() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, meta := range resp.ServerCertificateMetadataList {
-		resources = append(resources, &IamServerCertificate{
+		resources = append(resources, &IAMServerCertificate{
 			svc:  n.Service,
 			name: *meta.ServerCertificateName,
 		})
@@ -24,7 +24,7 @@ func (n *IamNuke) ListServerCertificates() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamServerCertificate) Remove() error {
+func (e *IAMServerCertificate) Remove() error {
 	_, err := e.svc.DeleteServerCertificate(&iam.DeleteServerCertificateInput{
 		ServerCertificateName: &e.name,
 	})
@@ -35,6 +35,6 @@ func (e *IamServerCertificate) Remove() error {
 	return nil
 }
 
-func (e *IamServerCertificate) String() string {
+func (e *IAMServerCertificate) String() string {
 	return e.name
 }

--- a/resources/iam-user-access-keys.go
+++ b/resources/iam-user-access-keys.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamUserAccessKeys struct {
+type IAMUserAccessKey struct {
 	svc         *iam.IAM
 	accessKeyId string
 	userName    string
 	status      string
 }
 
-func (n *IamNuke) ListUserAccessKeys() ([]Resource, error) {
+func (n *IAMNuke) ListUserAccessKeys() ([]Resource, error) {
 	resp, err := n.Service.ListUsers(nil)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (n *IamNuke) ListUserAccessKeys() ([]Resource, error) {
 		}
 
 		for _, meta := range resp.AccessKeyMetadata {
-			resources = append(resources, &IamUserAccessKeys{
+			resources = append(resources, &IAMUserAccessKey{
 				svc:         n.Service,
 				accessKeyId: *meta.AccessKeyId,
 				userName:    *meta.UserName,
@@ -42,7 +42,7 @@ func (n *IamNuke) ListUserAccessKeys() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamUserAccessKeys) Remove() error {
+func (e *IAMUserAccessKey) Remove() error {
 	_, err := e.svc.DeleteAccessKey(
 		&iam.DeleteAccessKeyInput{
 			AccessKeyId: &e.accessKeyId,
@@ -55,6 +55,6 @@ func (e *IamUserAccessKeys) Remove() error {
 	return nil
 }
 
-func (e *IamUserAccessKeys) String() string {
+func (e *IAMUserAccessKey) String() string {
 	return fmt.Sprintf("%s -> %s", e.userName, e.accessKeyId)
 }

--- a/resources/iam-user-policy-attachments.go
+++ b/resources/iam-user-policy-attachments.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
-type IamUserPolicyAttachment struct {
+type IAMUserPolicyAttachment struct {
 	svc        *iam.IAM
 	policyArn  string
 	policyName string
 	roleName   string
 }
 
-func (n *IamNuke) ListUserPolicyAttachments() ([]Resource, error) {
+func (n *IAMNuke) ListUserPolicyAttachments() ([]Resource, error) {
 	resp, err := n.Service.ListUsers(nil)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (n *IamNuke) ListUserPolicyAttachments() ([]Resource, error) {
 		}
 
 		for _, pol := range resp.AttachedPolicies {
-			resources = append(resources, &IamUserPolicyAttachment{
+			resources = append(resources, &IAMUserPolicyAttachment{
 				svc:        n.Service,
 				policyArn:  *pol.PolicyArn,
 				policyName: *pol.PolicyName,
@@ -42,7 +42,7 @@ func (n *IamNuke) ListUserPolicyAttachments() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamUserPolicyAttachment) Remove() error {
+func (e *IAMUserPolicyAttachment) Remove() error {
 	_, err := e.svc.DetachUserPolicy(
 		&iam.DetachUserPolicyInput{
 			PolicyArn: &e.policyArn,
@@ -55,6 +55,6 @@ func (e *IamUserPolicyAttachment) Remove() error {
 	return nil
 }
 
-func (e *IamUserPolicyAttachment) String() string {
+func (e *IAMUserPolicyAttachment) String() string {
 	return fmt.Sprintf("%s -> %s", e.roleName, e.policyName)
 }

--- a/resources/iam-users.go
+++ b/resources/iam-users.go
@@ -2,12 +2,12 @@ package resources
 
 import "github.com/aws/aws-sdk-go/service/iam"
 
-type IamUser struct {
+type IAMUser struct {
 	svc  *iam.IAM
 	name string
 }
 
-func (n *IamNuke) ListUsers() ([]Resource, error) {
+func (n *IAMNuke) ListUsers() ([]Resource, error) {
 	resp, err := n.Service.ListUsers(nil)
 	if err != nil {
 		return nil, err
@@ -15,7 +15,7 @@ func (n *IamNuke) ListUsers() ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.Users {
-		resources = append(resources, &IamUser{
+		resources = append(resources, &IAMUser{
 			svc:  n.Service,
 			name: *out.UserName,
 		})
@@ -24,7 +24,7 @@ func (n *IamNuke) ListUsers() ([]Resource, error) {
 	return resources, nil
 }
 
-func (e *IamUser) Remove() error {
+func (e *IAMUser) Remove() error {
 	_, err := e.svc.DeleteUser(&iam.DeleteUserInput{
 		UserName: &e.name,
 	})
@@ -35,6 +35,6 @@ func (e *IamUser) Remove() error {
 	return nil
 }
 
-func (e *IamUser) String() string {
+func (e *IAMUser) String() string {
 	return e.name
 }

--- a/resources/listers.go
+++ b/resources/listers.go
@@ -33,7 +33,7 @@ func GetListers(sess *session.Session) []ResourceLister {
 		elasticache      = ElasticacheNuke{elasticache.New(sess)}
 		elb              = ElbNuke{elb.New(sess)}
 		elbv2            = Elbv2Nuke{elbv2.New(sess)}
-		iam              = IamNuke{iam.New(sess)}
+		iam              = IAMNuke{iam.New(sess)}
 		kms              = KMSNuke{kms.New(sess)}
 		lambda           = LambdaNuke{lambda.New(sess)}
 		rds              = RDSNuke{rds.New(sess)}

--- a/resources/types.go
+++ b/resources/types.go
@@ -60,7 +60,7 @@ type Elbv2Nuke struct {
 	Service *elbv2.ELBV2
 }
 
-type IamNuke struct {
+type IAMNuke struct {
 	Service *iam.IAM
 }
 


### PR DESCRIPTION
- Rename `Iam.*` to `IAM.*`: consistent with the other service names: `EC2`, `RDS`, `KMS` etc.
- Rename `IamUserAccessKeys` to `IAMUserAccessKey`: all other resources are singular.
- Rename `ECRrepository` to `ECRRepository`: All other resources are camel-cased.

The capitalisation of acronyms is still inconsistent when it comes to resource names:
- `EC2DhcpOption`, `EC2Vpc`, `EC2VpnGateway`, `EC2VpnGatewayAttachment`, `EC2VpnConnection`, `EC2VpcEndpoint`
- `EC2NetworkACL`

@rebuy-de/prp-aws-nuke: Should we follow golang's best practice and capitalise acronyms or follow the golang aws-sdk in camel-casing it?