### PR TITLE
Fix capitalization of "IamUser"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ account-blacklist:
 accounts:
   "000000000000": # aws-nuke-example
     filters:
-      IAMUser:
+      IamUser:
       - "my-user"
       IAMUserPolicyAttachment:
       - "my-user -> AdministratorAccess"


### PR DESCRIPTION
This seems to matter. With `IAMUser`, my user doesn't get filtered out. With `IamUser`, it does.