### PR TITLE
Refactor AWS account validation

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,38 +53,37 @@ func (c *NukeConfig) InBlacklist(searchID string) bool {
 	return false
 }
 
-func (c *NukeConfig) ValidateAccount(accountID string, aliases []string) (*NukeConfigAccount, error) {
+func (c *NukeConfig) ValidateAccount(accountID string, aliases []string) error {
 	if !c.HasBlacklist() {
-		return nil, fmt.Errorf("The config file contains an empty blacklist. " +
+		return fmt.Errorf("The config file contains an empty blacklist. " +
 			"For safety reasons you need to specify at least one account ID. " +
 			"This should be your production account.")
 	}
 
 	if c.InBlacklist(accountID) {
-		return nil, fmt.Errorf("You are trying to nuke the account with the ID %s, "+
+		return fmt.Errorf("You are trying to nuke the account with the ID %s, "+
 			"but it is blacklisted. Aborting.", accountID)
 	}
 
 	if len(aliases) == 0 {
-		return nil, fmt.Errorf("The specified account doesn't have an alias. " +
+		return fmt.Errorf("The specified account doesn't have an alias. " +
 			"For safety reasons you need to specify an account alias. " +
 			"Your production account should contain the term 'prod'.")
 	}
 
 	for _, alias := range aliases {
 		if strings.Contains(strings.ToLower(alias), "prod") {
-			return nil, fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
+			return fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
 				"but it has the substring 'prod' in it. Aborting.", alias)
 		}
 	}
 
 	if _, ok := c.Accounts[accountID]; !ok {
-		return nil, fmt.Errorf("Your account ID '%s' isn't listed in the config. "+
+		return fmt.Errorf("Your account ID '%s' isn't listed in the config. "+
 			"Aborting.", accountID)
 	}
 
-	ac := c.Accounts[accountID]
-	return &ac, nil
+	return nil
 }
 
 func (c *NukeConfig) resolveDeprecations() error {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
 type NukeConfig struct {
@@ -49,6 +51,40 @@ func (c *NukeConfig) InBlacklist(searchID string) bool {
 	}
 
 	return false
+}
+
+func (c *NukeConfig) ValidateAccount(accountID string, aliases []string) (*NukeConfigAccount, error) {
+	if !c.HasBlacklist() {
+		return nil, fmt.Errorf("The config file contains an empty blacklist. " +
+			"For safety reasons you need to specify at least one account ID. " +
+			"This should be your production account.")
+	}
+
+	if c.InBlacklist(accountID) {
+		return nil, fmt.Errorf("You are trying to nuke the account with the ID %s, "+
+			"but it is blacklisted. Aborting.", accountID)
+	}
+
+	if len(aliases) == 0 {
+		return nil, fmt.Errorf("The specified account doesn't have an alias. " +
+			"For safety reasons you need to specify an account alias. " +
+			"Your production account should contain the term 'prod'.")
+	}
+
+	for _, alias := range aliases {
+		if strings.Contains(strings.ToLower(alias), "prod") {
+			return nil, fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
+				"but it has the substring 'prod' in it. Aborting.", alias)
+		}
+	}
+
+	if _, ok := c.Accounts[accountID]; !ok {
+		return nil, fmt.Errorf("Your account ID '%s' isn't listed in the config. "+
+			"Aborting.", accountID)
+	}
+
+	ac := c.Accounts[accountID]
+	return &ac, nil
 }
 
 func (c *NukeConfig) resolveDeprecations() error {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path"
 	"reflect"
 	"strings"
 	"testing"
@@ -46,12 +44,7 @@ func TestConfigBlacklist(t *testing.T) {
 }
 
 func TestLoadExampleConfig(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	config, err := LoadConfig(path.Join(cwd, "..", "config", "example.yaml"))
+	config, err := LoadConfig("test-fixtures/example.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,12 +138,7 @@ func TestResolveDeprecations(t *testing.T) {
 }
 
 func TestConfigValidation(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	config, err := LoadConfig(path.Join(cwd, "..", "config", "example.yaml"))
+	config, err := LoadConfig("test-fixtures/example.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +159,7 @@ func TestConfigValidation(t *testing.T) {
 	for i, tc := range cases {
 		name := fmt.Sprintf("%d_%s/%v/%t", i, tc.ID, tc.Aliases, tc.ShouldFail)
 		t.Run(name, func(t *testing.T) {
-			_, err := config.ValidateAccount(tc.ID, tc.Aliases)
+			err := config.ValidateAccount(tc.ID, tc.Aliases)
 			if tc.ShouldFail && err == nil {
 				t.Fatal("Expected an error but didn't get one.")
 			}

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -13,8 +13,6 @@ type Nuke struct {
 	Account    awsutil.Account
 	Config     *NukeConfig
 
-	accountConfig NukeConfigAccount
-
 	ForceSleep time.Duration
 
 	items Queue
@@ -35,11 +33,10 @@ func (n *Nuke) Run() error {
 
 	fmt.Printf("aws-nuke version %s - %s - %s\n\n", BuildVersion, BuildDate, BuildHash)
 
-	accountConfig, err := n.Config.ValidateAccount(n.Account.ID(), n.Account.Aliases())
+	err = n.Config.ValidateAccount(n.Account.ID(), n.Account.Aliases())
 	if err != nil {
 		return err
 	}
-	n.accountConfig = *accountConfig
 
 	fmt.Printf("Do you really want to nuke the account with "+
 		"the ID %s and the alias '%s'?\n", n.Account.ID(), n.Account.Alias())
@@ -138,6 +135,8 @@ func (n *Nuke) Scan() error {
 }
 
 func (n *Nuke) Filter(item *Item) {
+	accountConfig := n.Config.Accounts[n.Account.ID()]
+
 	checker, ok := item.Resource.(resources.Filter)
 	if ok {
 		err := checker.Filter()
@@ -148,7 +147,7 @@ func (n *Nuke) Filter(item *Item) {
 		}
 	}
 
-	filters, ok := n.accountConfig.Filters[item.Service]
+	filters, ok := accountConfig.Filters[item.Service]
 	if !ok {
 		return
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,12 @@ func NewRootCommand() *cobra.Command {
 
 		command.SilenceUsage = true
 
-		n := NewNuke(params, creds)
+		account, err := awsutil.NewAccount(creds)
+		if err != nil {
+			return err
+		}
+
+		n := NewNuke(params, *account)
 
 		n.Config, err = LoadConfig(n.Parameters.ConfigPath)
 		if err != nil {

--- a/cmd/test-fixtures/example.yaml
+++ b/cmd/test-fixtures/example.yaml
@@ -1,0 +1,13 @@
+---
+regions:
+  - "eu-west-1"
+account-blacklist:
+- 1234567890
+
+accounts:
+  555133742:
+    filters:
+      IAMRole:
+      - "uber.admin"
+      IAMRolePolicyAttachment:
+      - "uber.admin -> AdministratorAccess"

--- a/pkg/awsutil/account.go
+++ b/pkg/awsutil/account.go
@@ -1,0 +1,60 @@
+package awsutil
+
+import (
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+const DefaultRegion = "us-east-1" // This is the only region which cannot be disabled.
+
+type Account struct {
+	Credentials
+
+	id      string
+	aliases []string
+}
+
+func NewAccount(creds Credentials) (*Account, error) {
+	account := Account{
+		Credentials: creds,
+	}
+
+	sess, err := account.Session(DefaultRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	identityOutput, err := sts.New(sess).GetCallerIdentity(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	aliasesOutput, err := iam.New(sess).ListAccountAliases(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	aliases := []string{}
+	for _, alias := range aliasesOutput.AccountAliases {
+		if alias != nil {
+			aliases = append(aliases, *alias)
+		}
+	}
+
+	account.id = *identityOutput.Account
+	account.aliases = aliases
+
+	return &account, nil
+}
+
+func (a *Account) ID() string {
+	return a.id
+}
+
+func (a *Account) Alias() string {
+	return a.aliases[0]
+}
+
+func (a *Account) Aliases() []string {
+	return a.aliases
+}


### PR DESCRIPTION
* move AWS account queries into `awsutil` package to slim down `cmd` package
* move account validation from `Nuke` to the actual config struct
* add tests for account validation

@rebuy-de/prp-aws-nuke Please review. 
 
This is a preparation for #66.