### PR TITLE
adds support for s3 object versions

### DIFF
--- a/resources/util.go
+++ b/resources/util.go
@@ -1,5 +1,12 @@
 package resources
 
+func UnPtrBool(ptr *bool, def bool) bool {
+	if ptr == nil {
+		return def
+	}
+	return *ptr
+}
+
 func EqualStringPtr(v1, v2 *string) bool {
 	if v1 == nil && v2 == nil {
 		return true


### PR DESCRIPTION
> Closes #62 #64 #67

I tried to rebase or merge #67, but I horribly failed. Therefore I had to manually apply the patch. Changes from #67:

* uses the new resources API
* doesn't print and filter the version ID for latest object
* actually deletes the objects

@rebuy-de/prp-aws-nuke Please review.