### PR TITLE
Add EC2 Snapshot Deletion and AMI Deletion

### DIFF
--- a/resources/ec2-images.go
+++ b/resources/ec2-images.go
@@ -1,0 +1,50 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2Image struct {
+	svc *ec2.EC2
+	id  string
+}
+
+func init() {
+	register("EC2Image", ListEC2Images)
+}
+
+func ListEC2Images(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	params := &ec2.DescribeImagesInput{
+		Owners: []*string{
+			aws.String("self"),
+		},
+	}
+	resp, err := svc.DescribeImages(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.Images {
+		resources = append(resources, &EC2Image{
+			svc: svc,
+			id:  *out.ImageId,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *EC2Image) Remove() error {
+	_, err := e.svc.DeregisterImage(&ec2.DeregisterImageInput{
+		ImageId: &e.id,
+	})
+	return err
+}
+
+func (e *EC2Image) String() string {
+	return e.id
+}

--- a/resources/ec2-snapshots.go
+++ b/resources/ec2-snapshots.go
@@ -1,0 +1,50 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2Snapshot struct {
+	svc *ec2.EC2
+	id  string
+}
+
+func init() {
+	register("EC2Snapshot", ListEC2Snapshots)
+}
+
+func ListEC2Snapshots(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	params := &ec2.DescribeSnapshotsInput{
+		OwnerIds: []*string{
+			aws.String("self"),
+		},
+	}
+	resp, err := svc.DescribeSnapshots(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.Snapshots {
+		resources = append(resources, &EC2Snapshot{
+			svc: svc,
+			id:  *out.SnapshotId,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *EC2Snapshot) Remove() error {
+	_, err := e.svc.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: &e.id,
+	})
+	return err
+}
+
+func (e *EC2Snapshot) String() string {
+	return e.id
+}


### PR DESCRIPTION
This fixes #78 and fixes #80 

```
us-east-1 - EC2Volume - 'vol-01901abaa8d296376' - triggered remove
us-east-1 - EC2Snapshot - 'snap-0a4b6c012e9d6a7ab' - InvalidSnapshot.InUse: The snapshot snap-0a4b6c012e9d6a7ab is currently in use by ami-a94db9d4
	status code: 400, request id: 0a332abf-7537-4624-84c2-0568df4e39b4
us-east-1 - EC2Image - 'ami-a94db9d4' - triggered remove
us-east-1 - EC2Image - 'ami-ac4cb8d1' - triggered remove

Removal requested: 3 waiting, 1 failed, 43 skipped, 0 finished

us-east-1 - EC2Volume - 'vol-01901abaa8d296376' - waiting
us-east-1 - EC2Snapshot - 'snap-0a4b6c012e9d6a7ab' - removed
us-east-1 - EC2Image - 'ami-a94db9d4' - waiting
us-east-1 - EC2Image - 'ami-ac4cb8d1' - waiting

Removal requested: 3 waiting, 0 failed, 43 skipped, 1 finished

us-east-1 - EC2Volume - 'vol-01901abaa8d296376' - removed
us-east-1 - EC2Image - 'ami-a94db9d4' - waiting
us-east-1 - EC2Image - 'ami-ac4cb8d1' - waiting

Removal requested: 2 waiting, 0 failed, 43 skipped, 2 finished

us-east-1 - EC2Image - 'ami-a94db9d4' - waiting
us-east-1 - EC2Image - 'ami-ac4cb8d1' - waiting

Removal requested: 2 waiting, 0 failed, 43 skipped, 2 finished

us-east-1 - EC2Image - 'ami-a94db9d4' - removed
us-east-1 - EC2Image - 'ami-ac4cb8d1' - removed
Removal requested: 0 waiting, 0 failed, 43 skipped, 4 finished

Nuke complete: 0 failed, 43 skipped, 4 finished.
```