### PR TITLE
Feature/devicefarm

### DIFF
--- a/resources/devicefarm-projects.go
+++ b/resources/devicefarm-projects.go
@@ -1,0 +1,57 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+)
+
+type DeviceFarmProject struct {
+	svc *devicefarm.DeviceFarm
+	ARN *string
+}
+
+func init() {
+	register("DeviceFarmProject", ListDeviceFarmProjects)
+}
+
+func ListDeviceFarmProjects(sess *session.Session) ([]Resource, error) {
+	svc := devicefarm.New(sess)
+	resources := []Resource{}
+
+	params := &devicefarm.ListProjectsInput{}
+
+	for {
+		output, err := svc.ListProjects(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, project := range output.Projects {
+			resources = append(resources, &DeviceFarmProject{
+				svc: svc,
+				ARN: project.Arn,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *DeviceFarmProject) Remove() error {
+
+	_, err := f.svc.DeleteProject(&devicefarm.DeleteProjectInput{
+		Arn: f.ARN,
+	})
+
+	return err
+}
+
+func (f *DeviceFarmProject) String() string {
+	return *f.ARN
+}


### PR DESCRIPTION
How should I handle Regions which dont support the service (or make the error cleaner)

ERRO[0001] Listing with resources.ResourceLister failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.
    !!! RequestError: send request failed
    !!! caused by: Post https://devicefarm.us-east-1.amazonaws.com/: dial tcp: lookup devicefarm.us-east-1.amazonaws.com: no such host
ERRO[0002] Listing with resources.ResourceLister failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.
    !!! RequestError: send request failed
    !!! caused by: Post https://devicefarm.us-east-2.amazonaws.com/: dial tcp: lookup devicefarm.us-east-2.amazonaws.com: no such host
us-west-2 - DeviceFarmProject - 'arn:aws:devicefarm:us-west-2:999999999999:project:fc78472b-96d0-4234-aa2e-0cfa72dc3db6' - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.