### PR TITLE
fix error reporting

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,7 +25,7 @@ func Scan(region Region, resourceTypes []string) <-chan *Item {
 				}
 
 				dump := util.Indent(fmt.Sprintf("%v", err), "    !!! ")
-				log.Errorf("Listing with %T failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.\n%s", lister, dump)
+				log.Errorf("Listing %s failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.\n%s", resourceType, dump)
 				continue
 			}
 


### PR DESCRIPTION
Makes this:

```
RRO[0003] Listing with resources.ResourceLister failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.
    !!! InvalidInputException: Domain-related APIs are only available in the us-east-1 Region. Please set your Region configuration to us-east-1 to create, view, or edit these resources.
    !!! 	status code: 400, request id: 6599057b-26a0-11e8-9adb-839c15402d16 
```

to this:

```
ERRO[0006] Listing with LightsailDomain failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.
    !!! InvalidInputException: Domain-related APIs are only available in the us-east-1 Region. Please set your Region configuration to us-east-1 to create, view, or edit these resources.
    !!! 	status code: 400, request id: 171da9c9-26a1-11e8-ba98-d7a54aa6d996 
```

I though I already fixed it, but apparently I only dreamed about this.

@rebuy-de/prp-aws-nuke Please review.