### PR TITLE
fix ligthsail region

### DIFF
--- a/resources/lightsail-domains.go
+++ b/resources/lightsail-domains.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 )
@@ -17,6 +18,11 @@ func init() {
 func ListLightsailDomains(sess *session.Session) ([]Resource, error) {
 	svc := lightsail.New(sess)
 	resources := []Resource{}
+
+	if sess.Config.Region == nil || *sess.Config.Region != endpoints.UsEast1RegionID {
+		// LightsailDomain only supports us-east-1
+		return resources, nil
+	}
 
 	params := &lightsail.GetDomainsInput{}
 


### PR DESCRIPTION
Fixes this error:

```
ERRO[0004] Listing with LightsailDomain failed. Please report this to https://github.com/rebuy-de/aws-nuke/issues/new.
    !!! InvalidInputException: Domain-related APIs are only available in the us-east-1 Region. Please set your Region configuration to us-east-1 to create, view, or edit these resources.
    !!! 	status code: 400, request id: cf5a1f23-26a1-11e8-b93c-77bf2f94ebab
```

> Related to #124 

@rebuy-de/prp-aws-nuke Please review.
/cc @tomvachon 