### PR TITLE
Add SES Support

### DIFF
--- a/resources/ses-configurationsets.go
+++ b/resources/ses-configurationsets.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+type SESConfigurationSet struct {
+	svc  *ses.SES
+	name *string
+}
+
+func init() {
+	register("SESConfigurationSet", ListSESConfigurationSets)
+}
+
+func ListSESConfigurationSets(sess *session.Session) ([]Resource, error) {
+	svc := ses.New(sess)
+	resources := []Resource{}
+
+	params := &ses.ListConfigurationSetsInput{
+		MaxItems: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListConfigurationSets(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, configurationSet := range output.ConfigurationSets {
+			resources = append(resources, &SESConfigurationSet{
+				svc:  svc,
+				name: configurationSet.Name,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SESConfigurationSet) Remove() error {
+
+	_, err := f.svc.DeleteConfigurationSet(&ses.DeleteConfigurationSetInput{
+		ConfigurationSetName: f.name,
+	})
+
+	return err
+}
+
+func (f *SESConfigurationSet) String() string {
+	return *f.name
+}

--- a/resources/ses-identities.go
+++ b/resources/ses-identities.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+type SESIdentity struct {
+	svc      *ses.SES
+	identity *string
+}
+
+func init() {
+	register("SESIdentity", ListSESIdentities)
+}
+
+func ListSESIdentities(sess *session.Session) ([]Resource, error) {
+	svc := ses.New(sess)
+	resources := []Resource{}
+
+	params := &ses.ListIdentitiesInput{
+		MaxItems: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListIdentities(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, identity := range output.Identities {
+			resources = append(resources, &SESIdentity{
+				svc:      svc,
+				identity: identity,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SESIdentity) Remove() error {
+
+	_, err := f.svc.DeleteIdentity(&ses.DeleteIdentityInput{
+		Identity: f.identity,
+	})
+
+	return err
+}
+
+func (f *SESIdentity) String() string {
+	return *f.identity
+}

--- a/resources/ses-receiptfilters.go
+++ b/resources/ses-receiptfilters.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+type SESReceiptFilter struct {
+	svc  *ses.SES
+	name *string
+}
+
+func init() {
+	register("SESReceiptFilter", ListSESReceiptFilters)
+}
+
+func ListSESReceiptFilters(sess *session.Session) ([]Resource, error) {
+	svc := ses.New(sess)
+	resources := []Resource{}
+
+	params := &ses.ListReceiptFiltersInput{}
+
+	output, err := svc.ListReceiptFilters(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, filter := range output.Filters {
+		resources = append(resources, &SESReceiptFilter{
+			svc:  svc,
+			name: filter.Name,
+		})
+	}
+
+	return resources, nil
+}
+
+func (f *SESReceiptFilter) Remove() error {
+
+	_, err := f.svc.DeleteReceiptFilter(&ses.DeleteReceiptFilterInput{
+		FilterName: f.name,
+	})
+
+	return err
+}
+
+func (f *SESReceiptFilter) String() string {
+	return *f.name
+}

--- a/resources/ses-receiptrulesets.go
+++ b/resources/ses-receiptrulesets.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+type SESReceiptRuleSet struct {
+	svc           *ses.SES
+	name          *string
+	activeRuleSet bool
+}
+
+func init() {
+	register("SESReceiptRuleSet", ListSESReceiptRuleSets)
+}
+
+func ListSESReceiptRuleSets(sess *session.Session) ([]Resource, error) {
+	svc := ses.New(sess)
+	resources := []Resource{}
+
+	params := &ses.ListReceiptRuleSetsInput{}
+
+	output, err := svc.ListReceiptRuleSets(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ruleSet := range output.RuleSets {
+
+		//Check active state
+		ruleSetState := false
+		ruleName := ruleSet.Name
+
+		activeRuleSetOutput, err := svc.DescribeActiveReceiptRuleSet(&ses.DescribeActiveReceiptRuleSetInput{})
+		if err != nil {
+			return nil, err
+		}
+		if activeRuleSetOutput.Metadata == nil {
+			ruleSetState = false
+		} else if *ruleName == *activeRuleSetOutput.Metadata.Name {
+			ruleSetState = true
+		}
+
+		resources = append(resources, &SESReceiptRuleSet{
+			svc:           svc,
+			name:          ruleName,
+			activeRuleSet: ruleSetState,
+		})
+	}
+
+	return resources, nil
+}
+
+func (f *SESReceiptRuleSet) Remove() error {
+
+	_, err := f.svc.DeleteReceiptRuleSet(&ses.DeleteReceiptRuleSetInput{
+		RuleSetName: f.name,
+	})
+
+	return err
+}
+
+func (f *SESReceiptRuleSet) String() string {
+	return *f.name
+}
+
+func (f *SESReceiptRuleSet) Filter() error {
+	if f.activeRuleSet == true {
+		return fmt.Errorf("cannot delete active ruleset")
+	}
+	return nil
+}

--- a/resources/ses-templates.go
+++ b/resources/ses-templates.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+type SESTemplate struct {
+	svc  *ses.SES
+	name *string
+}
+
+func init() {
+	register("SESTemplate", ListSESTemplates)
+}
+
+func ListSESTemplates(sess *session.Session) ([]Resource, error) {
+	svc := ses.New(sess)
+	resources := []Resource{}
+
+	params := &ses.ListTemplatesInput{
+		MaxItems: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListTemplates(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, templateMetadata := range output.TemplatesMetadata {
+			resources = append(resources, &SESTemplate{
+				svc:  svc,
+				name: templateMetadata.Name,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SESTemplate) Remove() error {
+
+	_, err := f.svc.DeleteTemplate(&ses.DeleteTemplateInput{
+		TemplateName: f.name,
+	})
+
+	return err
+}
+
+func (f *SESTemplate) String() string {
+	return *f.name
+}


### PR DESCRIPTION
We cannot delete the Active Rule Set and there is no SDK function to invoke the "SetActiveReceiptRuleSet" API, so I am filtering it via a secondary describe call and a name matching