### PR TITLE
Add WAF Regional Support for Rules and WebACLs

### DIFF
--- a/resources/wafregional-rules.go
+++ b/resources/wafregional-rules.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+)
+
+type WAFRegionalRule struct {
+	svc *wafregional.WAFRegional
+	ID  *string
+}
+
+func init() {
+	register("WAFRegionalRule", ListWAFRegionalRules)
+}
+
+func ListWAFRegionalRules(sess *session.Session) ([]Resource, error) {
+	svc := wafregional.New(sess)
+	resources := []Resource{}
+
+	params := &waf.ListRulesInput{
+		Limit: aws.Int64(50),
+	}
+
+	for {
+		resp, err := svc.ListRules(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rule := range resp.Rules {
+			resources = append(resources, &WAFRegionalRule{
+				svc: svc,
+				ID:  rule.RuleId,
+			})
+		}
+
+		if resp.NextMarker == nil {
+			break
+		}
+
+		params.NextMarker = resp.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *WAFRegionalRule) Remove() error {
+
+	tokenOutput, err := f.svc.GetChangeToken(&waf.GetChangeTokenInput{})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteRule(&waf.DeleteRuleInput{
+		RuleId:      f.ID,
+		ChangeToken: tokenOutput.ChangeToken,
+	})
+
+	return err
+}
+
+func (f *WAFRegionalRule) String() string {
+	return *f.ID
+}

--- a/resources/wafregional-webacl-rule-attachments.go
+++ b/resources/wafregional-webacl-rule-attachments.go
@@ -1,0 +1,95 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+)
+
+type WAFRegionalWebACLRuleAttachment struct {
+	svc           *wafregional.WAFRegional
+	webACLID      *string
+	activatedRule *waf.ActivatedRule
+}
+
+func init() {
+	register("WAFRegionalWebACLRuleAttachment", ListWAFRegionalWebACLRuleAttachments)
+}
+
+func ListWAFRegionalWebACLRuleAttachments(sess *session.Session) ([]Resource, error) {
+	svc := wafregional.New(sess)
+	resources := []Resource{}
+	webACLs := []*waf.WebACLSummary{}
+
+	params := &waf.ListWebACLsInput{
+		Limit: aws.Int64(50),
+	}
+
+	//List All Web ACL's
+	for {
+		resp, err := svc.ListWebACLs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, webACL := range resp.WebACLs {
+			webACLs = append(webACLs, webACL)
+		}
+
+		if resp.NextMarker == nil {
+			break
+		}
+
+		params.NextMarker = resp.NextMarker
+	}
+
+	webACLParams := &waf.GetWebACLInput{}
+
+	for _, webACL := range webACLs {
+		webACLParams.WebACLId = webACL.WebACLId
+
+		resp, err := svc.GetWebACL(webACLParams)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, webACLRule := range resp.WebACL.Rules {
+			resources = append(resources, &WAFRegionalWebACLRuleAttachment{
+				svc:           svc,
+				webACLID:      webACL.WebACLId,
+				activatedRule: webACLRule,
+			})
+		}
+
+	}
+
+	return resources, nil
+}
+
+func (f *WAFRegionalWebACLRuleAttachment) Remove() error {
+
+	tokenOutput, err := f.svc.GetChangeToken(&waf.GetChangeTokenInput{})
+	if err != nil {
+		return err
+	}
+
+	webACLUpdate := &waf.WebACLUpdate{
+		Action:        aws.String("DELETE"),
+		ActivatedRule: f.activatedRule,
+	}
+
+	_, err = f.svc.UpdateWebACL(&waf.UpdateWebACLInput{
+		WebACLId:    f.webACLID,
+		ChangeToken: tokenOutput.ChangeToken,
+		Updates:     []*waf.WebACLUpdate{webACLUpdate},
+	})
+
+	return err
+}
+
+func (f *WAFRegionalWebACLRuleAttachment) String() string {
+	return fmt.Sprintf("%s -> %s", *f.webACLID, *f.activatedRule.RuleId)
+}

--- a/resources/wafregional-webacls.go
+++ b/resources/wafregional-webacls.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+)
+
+type WAFRegionalWebACL struct {
+	svc *wafregional.WAFRegional
+	ID  *string
+}
+
+func init() {
+	register("WAFRegionalWebACL", ListWAFRegionalWebACLs)
+}
+
+func ListWAFRegionalWebACLs(sess *session.Session) ([]Resource, error) {
+	svc := wafregional.New(sess)
+	resources := []Resource{}
+
+	params := &waf.ListWebACLsInput{
+		Limit: aws.Int64(50),
+	}
+
+	for {
+		resp, err := svc.ListWebACLs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, webACL := range resp.WebACLs {
+			resources = append(resources, &WAFRegionalWebACL{
+				svc: svc,
+				ID:  webACL.WebACLId,
+			})
+		}
+
+		if resp.NextMarker == nil {
+			break
+		}
+
+		params.NextMarker = resp.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *WAFRegionalWebACL) Remove() error {
+
+	tokenOutput, err := f.svc.GetChangeToken(&waf.GetChangeTokenInput{})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteWebACL(&waf.DeleteWebACLInput{
+		WebACLId:    f.ID,
+		ChangeToken: tokenOutput.ChangeToken,
+	})
+
+	return err
+}
+
+func (f *WAFRegionalWebACL) String() string {
+	return *f.ID
+}


### PR DESCRIPTION
Note: WAFRegional re-uses WAF types for Inputs
This is not full coverage of the product but does cover all "cost"-based assets