### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ account-blacklist:
 
 resource-types:
   # don't nuke IAM users
-  exclude:
+  excludes:
   - IAMUser
 
 accounts:


### PR DESCRIPTION
> Related to https://github.com/rebuy-de/aws-nuke/issues/170.

It is actually plural.

@rebuy-de/prp-aws-nuke Please review.