### PR TITLE
fix more typos - fixes #170

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ account-blacklist:
 
 resource-types:
   # don't nuke IAM users
-  exclude:
+  excludes:
   - IAMUser
 
 accounts:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 	"reflect"
 	"strings"
 	"testing"
@@ -62,7 +63,15 @@ func TestLoadExampleConfig(t *testing.T) {
 						NewExactFilter("uber.admin -> AdministratorAccess"),
 					},
 				},
+				ResourceTypes: ResourceTypes{
+					types.Collection{"S3Bucket"},
+					nil,
+				},
 			},
+		},
+		ResourceTypes: ResourceTypes{
+			Targets: types.Collection{"S3Object", "S3Bucket"},
+			Excludes: types.Collection{"IAMRole"},
 		},
 	}
 

--- a/pkg/config/test-fixtures/example.yaml
+++ b/pkg/config/test-fixtures/example.yaml
@@ -5,16 +5,16 @@ account-blacklist:
 - 1234567890
 
 resource-types:
-  target:
+  targets:
   - S3Object
   - S3Bucket
-  exclude:
+  excludes:
   - IAMRole
 
 accounts:
   555133742:
     resource-types:
-      target:
+      targets:
       - S3Bucket
     filters:
       IAMRole:


### PR DESCRIPTION
it's always plural, see also #171