### PR TITLE
WIP: Initial Test Harness

### DIFF
--- a/resources/ec2-subnets.tf
+++ b/resources/ec2-subnets.tf
@@ -1,0 +1,16 @@
+resource "aws_subnet" "subnet" {
+  vpc_id     = "${aws_vpc.dep_vpc.id}"
+  cidr_block = "10.0.0.0/24"
+
+  tags {
+    Name = "AWSNukeTest"
+  }
+}
+
+resource "aws_vpc" "dep_vpc" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "AWSNukeTest"
+  }
+}

--- a/resources/ec2-subnets_test.go
+++ b/resources/ec2-subnets_test.go
@@ -1,0 +1,9 @@
+package resources
+
+import "testing"
+
+func TestEC2Subnet(t *testing.T) {
+	if err := ResourceTypeTest("aws_subnet", "subnet", "EC2Subnet", t); err != nil {
+		t.Error(err)
+	}
+}

--- a/resources/ec2-volume.tf
+++ b/resources/ec2-volume.tf
@@ -1,0 +1,8 @@
+resource "aws_ebs_volume" "volume" {
+  availability_zone = "eu-west-1a"
+  size = 1
+
+  tags {
+    Name = "AWSNukeTest"
+  }
+}

--- a/resources/ec2-volume_test.go
+++ b/resources/ec2-volume_test.go
@@ -1,0 +1,9 @@
+package resources
+
+import "testing"
+
+func TestEC2Volume(t *testing.T) {
+	if err := ResourceTypeTest("aws_ebs_volume", "volume", "EC2Volume", t); err != nil {
+		t.Error(err)
+	}
+}

--- a/resources/ec2-vpc.tf
+++ b/resources/ec2-vpc.tf
@@ -1,0 +1,7 @@
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "AWSNukeTest"
+  }
+}

--- a/resources/ec2-vpc_test.go
+++ b/resources/ec2-vpc_test.go
@@ -1,0 +1,9 @@
+package resources
+
+import "testing"
+
+func TestEC2VPC(t *testing.T) {
+	if err := ResourceTypeTest("aws_vpc", "vpc", "EC2VPC", t); err != nil {
+		t.Error(err)
+	}
+}

--- a/resources/example.yaml
+++ b/resources/example.yaml
@@ -1,0 +1,15 @@
+regions:
+- "global" # This is for all global resource types e.g. IAM
+- "eu-west-1"
+
+account-blacklist:
+- 1234567890
+
+accounts:
+  1234567890:
+    filters:
+      IAMUser:
+      - "admin"
+      IAMUserPolicyAttachment:
+      - "admin -> AdministratorAccess"
+

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region = "eu-west-1"
+  version = "~> 1.11"
+}
+

--- a/resources/main_test.go
+++ b/resources/main_test.go
@@ -1,0 +1,121 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+var debugFlag = true
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+
+	// Setup
+	os.Setenv("TF_IN_AUTOMATION", "1")
+	if err := RunCmd("terraform", "init", "-input=false", "-no-color"); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Test
+	code := m.Run()
+
+	// Teardown
+	fmt.Println("Teardown: destroying all terraform resources of the test suite")
+	RunCmd("terraform", "destroy", "-input=false", "-no-color", "-auto-approve")
+
+	os.Exit(code)
+}
+
+func ResourceTypeTest(tfType, tfName, nukeType string, t *testing.T) error {
+	tfResourcePath := tfType + "." + tfName
+
+	// Validate target resources do not exist yet.
+	planfile, preCreateDiff, err := CreatePlan([]string{tfResourcePath})
+	if len(preCreateDiff) == 0 {
+		return fmt.Errorf(`no resources to create. The resource may already exist: "%s"`, tfResourcePath)
+	}
+	fmt.Println("Plan to create the following resources:", preCreateDiff)
+
+	// Apply the plan. Terraform also creates the resources' dependencies.
+	if err := TerraformApplyPlan(planfile); err != nil {
+		return err
+	}
+
+	// Validate resources have been applied.
+	fmt.Println("Validate resources have been created")
+	planfile, preNukeDiff, err := CreatePlan([]string{tfResourcePath})
+	if err != nil {
+		return err
+	}
+	if len(preNukeDiff) > 0 {
+		fmt.Errorf("some resources have not been created. This is likely not caused by AWSNuke - %v", preNukeDiff)
+	}
+
+	// Destroy resources of given type.
+	RunCmd("aws-nuke", "-c", "./example.yaml", "--force", "--profile", "default", "--no-dry-run", "--target", nukeType)
+
+	// Remove resource from state to avoid ResourceNotFound error.
+	RunCmd("terraform", "state", "rm", tfResourcePath)
+
+	// Validate resources have been destroyed.
+	planfile, postNukeDiff, err := CreatePlan([]string{tfResourcePath})
+	if err != nil {
+		return err
+	}
+	if len(postNukeDiff) < len(preCreateDiff) {
+		t.Errorf("not all resources created have been destroyed")
+	} else if len(postNukeDiff) > len(preCreateDiff) {
+		t.Errorf("more resources have been destroyed than created. The AWS account was likely not empty")
+	}
+	return nil
+}
+
+func RunCmd(cmdName string, args ...string) error {
+	if debugFlag {
+		fmt.Println("os.exec:", cmdName, args)
+	}
+	cmd := exec.Command(cmdName, args...)
+	if debugFlag {
+		cmd.Stdout = os.Stdout
+	}
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func CreatePlan(targets []string) (*os.File, []string, error) {
+	var diffResources []string
+
+	f, err := ioutil.TempFile("/tmp", "AWSNuke")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	params := []string{"plan", "-out=" + f.Name()}
+	for _, t := range targets {
+		params = append(params, "-target="+t)
+	}
+
+	if err := RunCmd("terraform", params...); err != nil {
+		return nil, nil, err
+	}
+
+	plan, err := terraform.ReadPlan(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, m := range plan.Diff.Modules {
+		for rName := range m.Resources {
+			diffResources = append(diffResources, rName)
+		}
+	}
+	return f, diffResources, nil
+}
+
+func TerraformApplyPlan(planfile *os.File) error {
+	return RunCmd("terraform", "apply", "-input=false", "-auto-approve", planfile.Name())
+}

--- a/resources/ssm-maintenance-window.tf
+++ b/resources/ssm-maintenance-window.tf
@@ -1,0 +1,6 @@
+resource "aws_ssm_maintenance_window" "window" {
+  name     = "AWSNukeTest"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff   = 1
+}

--- a/resources/ssm-maintenancewindows_test.go
+++ b/resources/ssm-maintenancewindows_test.go
@@ -1,0 +1,9 @@
+package resources
+
+import "testing"
+
+func TestSSMMaintenanceWindow(t *testing.T) {
+	if err := ResourceTypeTest("aws_ssm_maintenance_window", "window", "SSMMaintenanceWindow", t); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
@rebuy-de/prp-aws-nuke WDYT?

This is rather a black box approach to the integration test. It heavily relies on Terraform. The resulting terraform state and configuration is not very pretty in the resources folder. I would look into moving it to `/tmp/`.

On the upside, the `resources/ssm-maintenancewindows_test.go` is rather concise.

More generally speaking, we would need an empty account to run these tests on.

It does take quite a while due to the 15s cooldown of `--force`. A flag or env variable to circumvent it would speed things up.