### PR TITLE
add placement groups, fix security group circular deps, s3 bucket filtering enhancement

### DIFF
--- a/resources/ec2-placement-groups.go
+++ b/resources/ec2-placement-groups.go
@@ -1,0 +1,63 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2PlacementGroup struct {
+	svc   *ec2.EC2
+	name  string
+	state string
+}
+
+func init() {
+	register("EC2PlacementGroup", ListEC2PlacementGroups)
+}
+
+func ListEC2PlacementGroups(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+
+	params := &ec2.DescribePlacementGroupsInput{}
+	resp, err := svc.DescribePlacementGroups(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.PlacementGroups {
+		resources = append(resources, &EC2PlacementGroup{
+			svc:   svc,
+			name:  *out.GroupName,
+			state: *out.State,
+		})
+	}
+
+	return resources, nil
+}
+
+func (p *EC2PlacementGroup) Filter() error {
+	if p.state == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+	return nil
+}
+
+func (p *EC2PlacementGroup) Remove() error {
+	params := &ec2.DeletePlacementGroupInput{
+		GroupName: &p.name,
+	}
+
+	_, err := p.svc.DeletePlacementGroup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *EC2PlacementGroup) String() string {
+	return p.name
+}

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -42,7 +42,7 @@ func DescribeS3Buckets(svc *s3.S3) ([]string, error) {
 		bucketLocationResponse, err := svc.GetBucketLocation(&s3.GetBucketLocationInput{Bucket: out.Name})
 
 		if err != nil {
-			return nil, err
+			continue
 		}
 
 		location := UnPtrString(bucketLocationResponse.LocationConstraint, endpoints.UsEast1RegionID)


### PR DESCRIPTION
* add EC2 placement groups
* security groups: revoke all IP permissions before destroying

It's possible for security groups to have circular dependencies on each
other, preventing the actual removal from ever working. If we remove the
rules first, it's possible for a future retry to succeed.
* don't fail entire S3 bucket list on one bucket

It's possible for a single S3 bucket to be in an undesirable state (i.e.
unattached to a region) and this will cause all buckets to be filtered.