### PR TITLE
Fix Release Batch on top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/rebuy-de/aws-nuke.svg?branch=master)](https://travis-ci.org/rebuy-de/aws-nuke)
 [![license](https://img.shields.io/github/license/rebuy-de/aws-nuke.svg)]()
-[![GitHub release](https://img.shields.io/github/release/rebuy-de/aws-nuke.svg)]()
+[![GitHub release](https://img.shields.io/github/release/rebuy-de/aws-nuke.svg)](https://github.com/rebuy-de/aws-nuke/releases)
 
 Nuke a whole AWS account and delete all its resources.
 


### PR DESCRIPTION
* targets "https://github.com/rebuy-de/aws-nuke/blob/master" which results in 404 for me
* changed it to target "https://github.com/rebuy-de/aws-nuke/releases"