### PR TITLE
fix hostname check

### DIFF
--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -148,7 +148,7 @@ func skipGlobalHandler(global bool) func(r *request.Request) {
 				r.Error = ErrSkipRequest(fmt.Sprintf("service '%s' is was not found in the endpoint list; assuming it is not global", service))
 			} else {
 				host := r.HTTPRequest.URL.Hostname()
-				_, err := net.LookupAddr(host)
+				_, err := net.LookupHost(host)
 				if err != nil {
 					log.Debug(err)
 					r.Error = ErrUnknownEndpoint(fmt.Sprintf("DNS lookup failed for %s; assuming it does not exist in this region", host))


### PR DESCRIPTION
> Fixes #208 

[`LookupAddr`](https://golang.org/pkg/net/#LookupAddr) does a revers IP lookup and [`LookupHost`](https://golang.org/pkg/net/#LookupHost) does what we actually want. No idea how I did this wrong and how it worked in my tests.

@rebuy-de/prp-aws-nuke @tomvachon Please review.