### PR TITLE
make resource ID optional

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -27,8 +27,12 @@ func Log(region Region, resourceType string, r resources.Resource, c color.Color
 	fmt.Printf(" - ")
 	ColorResourceType.Print(resourceType)
 	fmt.Printf(" - ")
-	ColorResourceID.Printf("'%s'", r.String())
-	fmt.Printf(" - ")
+
+	rString, ok := r.(resources.LegacyStringer)
+	if ok {
+		ColorResourceID.Print(rString.String())
+		fmt.Printf(" - ")
+	}
 
 	rProp, ok := r.(resources.ResourcePropertyGetter)
 	if ok {

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -255,7 +255,7 @@ func (n *Nuke) HandleWait(item *Item, cache map[string][]resources.Resource) {
 	}
 
 	for _, r := range left {
-		if r.String() == item.Resource.String() {
+		if item.Equals(r) {
 			checker, ok := r.(resources.Filter)
 			if ok {
 				err := checker.Filter()

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -51,3 +51,30 @@ func (p Properties) Get(key string) string {
 
 	return value
 }
+
+func (p Properties) Equals(o Properties) bool {
+	if p == nil && o == nil {
+		return true
+	}
+
+	if p == nil || o == nil {
+		return false
+	}
+
+	if len(p) != len(o) {
+		return false
+	}
+
+	for k, pv := range p {
+		ov, ok := o[k]
+		if !ok {
+			return false
+		}
+
+		if pv != ov {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -1,0 +1,65 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+func TestPropertiesEquals(t *testing.T) {
+	cases := []struct {
+		p1, p2 types.Properties
+		result bool
+	}{
+		{
+			p1:     nil,
+			p2:     nil,
+			result: true,
+		},
+		{
+			p1:     nil,
+			p2:     types.NewProperties(),
+			result: false,
+		},
+		{
+			p1:     types.NewProperties(),
+			p2:     types.NewProperties(),
+			result: true,
+		},
+		{
+			p1:     types.NewProperties().Set("blub", "blubber"),
+			p2:     types.NewProperties().Set("blub", "blubber"),
+			result: true,
+		},
+		{
+			p1:     types.NewProperties().Set("blub", "foo"),
+			p2:     types.NewProperties().Set("blub", "bar"),
+			result: false,
+		},
+		{
+			p1:     types.NewProperties().Set("bim", "baz").Set("blub", "blubber"),
+			p2:     types.NewProperties().Set("bim", "baz").Set("blub", "blubber"),
+			result: true,
+		},
+		{
+			p1:     types.NewProperties().Set("bim", "baz").Set("blub", "foo"),
+			p2:     types.NewProperties().Set("bim", "baz").Set("blub", "bar"),
+			result: false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if tc.p1.Equals(tc.p2) != tc.result {
+				t.Errorf("Test Case failed. Want %t. Got %t.", !tc.result, tc.result)
+				t.Errorf("p1: %s", tc.p1.String())
+				t.Errorf("p2: %s", tc.p2.String())
+			} else if tc.p2.Equals(tc.p1) != tc.result {
+				t.Errorf("Test Case reverse check failed. Want %t. Got %t.", !tc.result, tc.result)
+				t.Errorf("p1: %s", tc.p1.String())
+				t.Errorf("p2: %s", tc.p2.String())
+			}
+		})
+	}
+}

--- a/resources/interface.go
+++ b/resources/interface.go
@@ -13,12 +13,16 @@ type ResourceLister func(s *session.Session) ([]Resource, error)
 
 type Resource interface {
 	Remove() error
-	String() string
 }
 
 type Filter interface {
 	Resource
 	Filter() error
+}
+
+type LegacyStringer interface {
+	Resource
+	String() string
 }
 
 type ResourcePropertyGetter interface {


### PR DESCRIPTION
Make resource IDs optional (ie IDs from `String()` function). New resources should use the property feature instead.

Making legacy to avoid awkward resource IDs like this in `wafregional-ip-set-ips.go`:

```golang
return fmt.Sprintf("%s -> %s:%s", *r.ipSetid, *r.descriptor.Type, *r.descriptor.Value)
```

Describing [`waf.FieldToMatch`](https://godoc.org/github.com/aws/aws-sdk-go/service/waf#FieldToMatch) in a single string would be even more complex.

@rebuy-de/prp-aws-nuke Please review.