### PR TITLE
move properties

### DIFF
--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Properties map[string]string
+
+func NewProperties() Properties {
+	return make(Properties)
+}
+
+func (p Properties) String() string {
+	parts := []string{}
+	for k, v := range p {
+		parts = append(parts, fmt.Sprintf(`%s: "%v"`, k, v))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
+}
+
+func (p Properties) Set(key string, value interface{}) Properties {
+	if value == nil {
+		return p
+	}
+
+	switch v := value.(type) {
+	case *string:
+		p[key] = *v
+	case *bool:
+		p[key] = fmt.Sprint(*v)
+	case *int64:
+		p[key] = fmt.Sprint(*v)
+	case *int:
+		p[key] = fmt.Sprint(*v)
+	default:
+		// Fallback to Stringer interface. This produces gibberish on pointers,
+		// but is the only way to avoid reflection.
+		p[key] = fmt.Sprint(value)
+	}
+
+	return p
+}
+
+func (p Properties) Get(key string) string {
+	value, ok := p[key]
+	if !ok {
+		return ""
+	}
+
+	return value
+}

--- a/resources/ec2-security-groups.go
+++ b/resources/ec2-security-groups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2SecurityGroup struct {
@@ -81,8 +82,8 @@ func (sg *EC2SecurityGroup) Remove() error {
 	return nil
 }
 
-func (sg *EC2SecurityGroup) Properties() Properties {
-	return NewProperties().
+func (sg *EC2SecurityGroup) Properties() types.Properties {
+	return types.NewProperties().
 		Set("Name", sg.name)
 }
 

--- a/resources/ec2-vpc.go
+++ b/resources/ec2-vpc.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2VPC struct {
@@ -48,8 +49,8 @@ func (e *EC2VPC) Remove() error {
 	return nil
 }
 
-func (e *EC2VPC) Properties() Properties {
-	return NewProperties().
+func (e *EC2VPC) Properties() types.Properties {
+	return types.NewProperties().
 		Set("ID", e.id).
 		Set("IsDefault", e.isDefault)
 }

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type IAMRolePolicyAttachment struct {
@@ -70,8 +71,8 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 	return nil
 }
 
-func (e *IAMRolePolicyAttachment) Properties() Properties {
-	return NewProperties().
+func (e *IAMRolePolicyAttachment) Properties() types.Properties {
+	return types.NewProperties().
 		Set("RoleName", e.roleName).
 		Set("PolicyName", e.policyName)
 }

--- a/resources/iam-user-access-keys.go
+++ b/resources/iam-user-access-keys.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type IAMUserAccessKey struct {
@@ -62,8 +63,8 @@ func (e *IAMUserAccessKey) Remove() error {
 	return nil
 }
 
-func (e *IAMUserAccessKey) Properties() Properties {
-	return NewProperties().
+func (e *IAMUserAccessKey) Properties() types.Properties {
+	return types.NewProperties().
 		Set("UserName", e.userName).
 		Set("AccessKeyID", e.accessKeyId)
 }

--- a/resources/iam-user-policy-attachments.go
+++ b/resources/iam-user-policy-attachments.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type IAMUserPolicyAttachment struct {
@@ -62,8 +63,8 @@ func (e *IAMUserPolicyAttachment) Remove() error {
 	return nil
 }
 
-func (e *IAMUserPolicyAttachment) Properties() Properties {
-	return NewProperties().
+func (e *IAMUserPolicyAttachment) Properties() types.Properties {
+	return types.NewProperties().
 		Set("PolicyArn", e.policyArn).
 		Set("PolicyName", e.policyName).
 		Set("UserName", e.userName)

--- a/resources/interface.go
+++ b/resources/interface.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type ResourceListers map[string]ResourceLister
@@ -21,56 +21,9 @@ type Filter interface {
 	Filter() error
 }
 
-type Properties map[string]string
-
-func NewProperties() Properties {
-	return make(Properties)
-}
-
-func (p Properties) String() string {
-	parts := []string{}
-	for k, v := range p {
-		parts = append(parts, fmt.Sprintf(`%s: "%v"`, k, v))
-	}
-
-	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
-}
-
-func (p Properties) Set(key string, value interface{}) Properties {
-	if value == nil {
-		return p
-	}
-
-	switch v := value.(type) {
-	case *string:
-		p[key] = *v
-	case *bool:
-		p[key] = fmt.Sprint(*v)
-	case *int64:
-		p[key] = fmt.Sprint(*v)
-	case *int:
-		p[key] = fmt.Sprint(*v)
-	default:
-		// Fallback to Stringer interface. This produces gibberish on pointers,
-		// but is the only way to avoid reflection.
-		p[key] = fmt.Sprint(value)
-	}
-
-	return p
-}
-
-func (p Properties) Get(key string) string {
-	value, ok := p[key]
-	if !ok {
-		return ""
-	}
-
-	return value
-}
-
 type ResourcePropertyGetter interface {
 	Resource
-	Properties() Properties
+	Properties() types.Properties
 }
 
 var resourceListers = make(ResourceListers)

--- a/resources/route53-hosted-zones.go
+++ b/resources/route53-hosted-zones.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 func init() {
@@ -50,8 +51,8 @@ func (hz *Route53HostedZone) Remove() error {
 	return nil
 }
 
-func (hz *Route53HostedZone) Properties() Properties {
-	return NewProperties().
+func (hz *Route53HostedZone) Properties() types.Properties {
+	return types.NewProperties().
 		Set("Name", hz.name)
 }
 

--- a/resources/route53-resource-records.go
+++ b/resources/route53-resource-records.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type Route53ResourceRecordSet struct {
@@ -97,8 +98,8 @@ func (r *Route53ResourceRecordSet) Remove() error {
 	return nil
 }
 
-func (r *Route53ResourceRecordSet) Properties() Properties {
-	return NewProperties().
+func (r *Route53ResourceRecordSet) Properties() types.Properties {
+	return types.NewProperties().
 		Set("Name", r.data.Name).
 		Set("Type", r.data.Type)
 }

--- a/resources/s3-multipart-uploads.go
+++ b/resources/s3-multipart-uploads.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type S3MultipartUpload struct {
@@ -79,8 +80,8 @@ func (e *S3MultipartUpload) Remove() error {
 	return nil
 }
 
-func (e *S3MultipartUpload) Properties() Properties {
-	return NewProperties().
+func (e *S3MultipartUpload) Properties() types.Properties {
+	return types.NewProperties().
 		Set("Bucket", e.bucket).
 		Set("Key", e.key).
 		Set("UploadID", e.uploadID)

--- a/resources/s3-objects.go
+++ b/resources/s3-objects.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type S3Object struct {
@@ -96,8 +97,8 @@ func (e *S3Object) Remove() error {
 	return nil
 }
 
-func (e *S3Object) Properties() Properties {
-	return NewProperties().
+func (e *S3Object) Properties() types.Properties {
+	return types.NewProperties().
 		Set("Bucket", e.bucket).
 		Set("Key", e.key).
 		Set("VersionID", e.versionID).

--- a/resources/wafregional-ip-set-ips.go
+++ b/resources/wafregional-ip-set-ips.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type WAFRegionalIPSetIP struct {
@@ -81,8 +82,8 @@ func (r *WAFRegionalIPSetIP) Remove() error {
 	return err
 }
 
-func (r *WAFRegionalIPSetIP) Properties() Properties {
-	return NewProperties().
+func (r *WAFRegionalIPSetIP) Properties() types.Properties {
+	return types.NewProperties().
 		Set("IPSetID", r.ipSetid).
 		Set("Type", r.descriptor.Type).
 		Set("Value", r.descriptor.Value)

--- a/resources/wafregional-ip-sets.go
+++ b/resources/wafregional-ip-sets.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type WAFRegionalIPSet struct {
@@ -63,8 +64,8 @@ func (r *WAFRegionalIPSet) Remove() error {
 	return err
 }
 
-func (r *WAFRegionalIPSet) Properties() Properties {
-	return NewProperties().
+func (r *WAFRegionalIPSet) Properties() types.Properties {
+	return types.NewProperties().
 		Set("ID", r.id).
 		Set("Name", r.name)
 }

--- a/resources/wafregional-rule-predicates.go
+++ b/resources/wafregional-rule-predicates.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type WAFRegionalRulePredicate struct {
@@ -78,8 +79,8 @@ func (r *WAFRegionalRulePredicate) Remove() error {
 	return err
 }
 
-func (r *WAFRegionalRulePredicate) Properties() Properties {
-	return NewProperties().
+func (r *WAFRegionalRulePredicate) Properties() types.Properties {
+	return types.NewProperties().
 		Set("RuleID", r.ruleID).
 		Set("Type", r.predicate.Type).
 		Set("Negated", r.predicate.Negated).


### PR DESCRIPTION
I think it makes more sense to move the `Property` type into the `type` package.

@rebuy-de/prp-aws-nuke Please review.