### PR TITLE
Allow to invert Filter Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,17 @@ Route53HostedZone:
   value: "*.rebuy.cloud."
 ```
 
+####  Inverting Filter Results
+
+Any filter result can be inverted by using `invert: true`, for example:
+```yaml
+CloudFormationStack:
+- property: Name
+  value: "foo"
+  invert: true
+```
+In this case *any* CloudFormationStack ***but*** the ones called "foo" will be filtered. Be aware that *aws-nuke* internally takes every resource and applies every filter on it. If a filter matches, it marks the node as filtered.
+
 ## Install
 
 ### Use Released Binaries

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -189,6 +189,10 @@ func (n *Nuke) Filter(item *Item) error {
 			return err
 		}
 
+		if IsTrue(filter.Invert) {
+			match = !match
+		}
+
 		if match {
 			item.State = ItemStateFiltered
 			item.Reason = "filtered by config"

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -38,3 +38,7 @@ func ResolveResourceTypes(base types.Collection, include, exclude []types.Collec
 
 	return base
 }
+
+func IsTrue(s string) bool {
+	return strings.TrimSpace(strings.ToLower(s)) == "true"
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -61,3 +61,19 @@ func TestResolveResourceTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTrue(t *testing.T) {
+	falseStrings := []string{"", "false", "treu", "foo"}
+	for _, fs := range falseStrings {
+		if IsTrue(fs) {
+			t.Fatalf("IsTrue falsely returned 'true' for: %s", fs)
+		}
+	}
+
+	trueStrings := []string{"true", " true", "true ", " TrUe "}
+	for _, ts := range trueStrings {
+		if ! IsTrue(ts) {
+			t.Fatalf("IsTrue falsely returned 'false' for: %s", ts)
+		}
+	}
+}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -24,6 +24,7 @@ type Filter struct {
 	Property string
 	Type     FilterType
 	Value    string
+	Invert   string
 }
 
 func (f Filter) Match(o string) (bool, error) {
@@ -70,6 +71,7 @@ func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	f.Type = FilterType(m["type"])
 	f.Value = m["value"]
 	f.Property = m["property"]
+	f.Invert = m["invert"]
 	return nil
 }
 


### PR DESCRIPTION
Hi!

`invert: true` can be added to any filter statement and would invert such filter result. 

Can be useful to not only protect resources from being nuked, but to also explicitly define resources to be removed by inverting a filter result (else used for resource protection).

Cheers, Christian