### PR TITLE
Retain all CloudFormation resources in Deletion of CloudFormationStack

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -44,9 +44,20 @@ type CloudFormationStack struct {
 }
 
 func (cfs *CloudFormationStack) Remove() error {
-	_, err := cfs.svc.DeleteStack(&cloudformation.DeleteStackInput{
+	retainableResources, err := cfs.svc.ListStackResources(&cloudformation.ListStackResourcesInput{
 		StackName: cfs.stack.StackName,
 	})
+
+	retain := make([]*string, 0)
+	for _, r := range retainableResources.StackResourceSummaries {
+		retain = append(retain, r.LogicalResourceId)
+	}
+
+	cfs.svc.DeleteStack(&cloudformation.DeleteStackInput{
+		StackName:       cfs.stack.StackName,
+		RetainResources: retain,
+	})
+
 	return err
 }
 


### PR DESCRIPTION
This would be my suggestion on how to deal with CloudFormationStacks that get stuck in _**Deletion failed**_ state.
By retaining all resources that belong to the CloudFormationStacks we delete **just** the CloudFormationStack resource and **don't** cause cascading deletions. 
IMHO this should be the desired behavior. As with other resources, we just try to delete the resource itsself **EXcluding** the onces that depend on it.
The resources that were created from the CloudFormationStack and are left over after the CloudFormationStack is gone, should be deleted by their own resource implementation.
What do you think? 

ref: https://github.com/rebuy-de/aws-nuke/issues/238
ping @rebuy-de/prp-aws-nuke 
