### PR TITLE
Revert "Retain all CloudFormation resources in Deletion of CloudFormationStack"

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -44,20 +44,9 @@ type CloudFormationStack struct {
 }
 
 func (cfs *CloudFormationStack) Remove() error {
-	retainableResources, err := cfs.svc.ListStackResources(&cloudformation.ListStackResourcesInput{
+	_, err := cfs.svc.DeleteStack(&cloudformation.DeleteStackInput{
 		StackName: cfs.stack.StackName,
 	})
-
-	retain := make([]*string, 0)
-	for _, r := range retainableResources.StackResourceSummaries {
-		retain = append(retain, r.LogicalResourceId)
-	}
-
-	cfs.svc.DeleteStack(&cloudformation.DeleteStackInput{
-		StackName:       cfs.stack.StackName,
-		RetainResources: retain,
-	})
-
 	return err
 }
 


### PR DESCRIPTION
Turns out the conditions under which this solution was tested were flawed. Resources can only be retained when the CFS is already in `DELETE_FAILED` state.

Therefore we have to find a different solution to fix CFS. :crying_cat_face: 

Reverts rebuy-de/aws-nuke#242