### PR TITLE
Strip debug info using ldflags on build

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -7,6 +7,7 @@ BUILD_MACHINE=$(shell echo $$HOSTNAME)
 BUILD_USER=$(shell whoami)
 
 BUILD_FLAGS=-ldflags "\
+	-s -w \
 	-X '$(PACKAGE)/cmd.BuildVersion=$(BUILD_VERSION)' \
 	-X '$(PACKAGE)/cmd.BuildDate=$(BUILD_DATE)' \
 	-X '$(PACKAGE)/cmd.BuildHash=$(BUILD_HASH)' \


### PR DESCRIPTION
Adding the `-s -w` ldflags on build [strips debugging symbols](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/
) and reduces the resulting binary size by about a third before compression

```
❯ ls -lh aws-nuke*
-rwxr-xr-x  1 mark  staff    99M Aug 29 09:09 aws-nuke-v2.4.0.5.gfac485d-darwin-amd64
-rwxr-xr-x  1 mark  staff    67M Aug 29 09:11 aws-nuke-v2.4.0.5.gfac485d.dirty-darwin-amd64
```

```
❯ ./aws-nuke-v2.4.0.5.gfac485d.dirty-darwin-amd64 version
version:     v2.4.0.5.gfac485d.dirty
build date:  Wed Aug 29 09:10:56 MDT 2018
scm hash:    fac485df12c04ccbfccccbd5d7ce7623d005a1c5
environment: mark@Marks-MacBook-Pro.local
```