### PR TITLE
Add --max-wait-retries flag to bail out early if the script is stuck waiting

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -84,6 +84,7 @@ func (n *Nuke) Run() error {
 	}
 
 	failCount := 0
+	waitingCount := 0
 
 	for {
 		n.HandleQueue()
@@ -95,6 +96,16 @@ func (n *Nuke) Run() error {
 			failCount = failCount + 1
 		} else {
 			failCount = 0
+		}
+		if n.Parameters.MaxWaitRetries != 0 && n.items.Count(ItemStateWaiting, ItemStatePending) > 0 && n.items.Count(ItemStateNew) == 0 {
+			if waitingCount >= n.Parameters.MaxWaitRetries {
+				fmt.Printf("Max wait retries of %d exceeded.\n\n", n.Parameters.MaxWaitRetries)
+
+				break
+			}
+			waitingCount = waitingCount + 1
+		} else {
+			waitingCount = 0
 		}
 		if n.items.Count(ItemStateNew, ItemStatePending, ItemStateFailed, ItemStateWaiting) == 0 {
 			break

--- a/cmd/params.go
+++ b/cmd/params.go
@@ -13,6 +13,8 @@ type NukeParameters struct {
 
 	NoDryRun bool
 	Force    bool
+
+	MaxWaitRetries int
 }
 
 func (p *NukeParameters) Validate() error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,10 @@ func NewRootCommand() *cobra.Command {
 		&params.Force, "force", false,
 		"Don't ask for confirmation before deleting resources. "+
 			"Instead it waits 15s before continuing.")
+	command.PersistentFlags().IntVar(
+		&params.MaxWaitRetries, "max-wait-retries", 0,
+		"If specified, the program will exit if resources are stuck in waiting for this many iterations."+
+			"0 (default) disables early exit)")
 
 	command.AddCommand(NewVersionCommand())
 	command.AddCommand(NewResourceTypesCommand())

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ type NukeParameters struct {
 
 	NoDryRun bool
 	Force    bool
+
+	MaxWaitRetries int
 }
 
 func main() {


### PR DESCRIPTION
We want to get to a point where we can run `aws-nuke` through our CI/CD platform and have noticed that it can get stuck in a waiting state for a considerable length of time in some scenarios. 

This pull request aims to resolve that by adding a flag that, if set, will cause the program to bail out if it is waiting for `n` number of iterations and no new work has been discovered in that time.