### PR TITLE
Fix deletion of resources in DELETE_COMPLETE state

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -70,8 +70,11 @@ func (cfs *CloudFormationStack) Remove() error {
 		}
 
 		retain := make([]*string, 0)
+
 		for _, r := range retainableResources.StackResourceSummaries {
-			retain = append(retain, r.LogicalResourceId)
+			if *r.ResourceStatus != "DELETE_COMPLETE" {
+				retain = append(retain, r.LogicalResourceId)
+			}
 		}
 
 		_, err = cfs.svc.DeleteStack(&cloudformation.DeleteStackInput{


### PR DESCRIPTION
As described in https://github.com/rebuy-de/aws-nuke/issues/270 aws-nuke retains resources that are already in `DELETE_COMPLETE` state.
In order to not run into an error message here, we exclude them from the retain array.