### PR TITLE
Add ElasticacheReplicationGroup resource

### DIFF
--- a/resources/elasticache-replicationgroups.go
+++ b/resources/elasticache-replicationgroups.go
@@ -1,0 +1,54 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+type ElasticacheReplicationGroup struct {
+	svc     *elasticache.ElastiCache
+	groupID *string
+}
+
+func init() {
+	register("ElasticacheReplicationGroup", ListElasticacheReplicationGroups)
+}
+
+func ListElasticacheReplicationGroups(sess *session.Session) ([]Resource, error) {
+	svc := elasticache.New(sess)
+
+	params := &elasticache.DescribeReplicationGroupsInput{MaxRecords: aws.Int64(100)}
+	resp, err := svc.DescribeReplicationGroups(params)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []Resource
+
+	for _, replicationGroup := range resp.ReplicationGroups {
+		resources = append(resources, &ElasticacheReplicationGroup{
+			svc:     svc,
+			groupID: replicationGroup.ReplicationGroupId,
+		})
+	}
+
+	return resources, nil
+}
+
+func (i *ElasticacheReplicationGroup) Remove() error {
+	params := &elasticache.DeleteReplicationGroupInput{
+		ReplicationGroupId: i.groupID,
+	}
+
+	_, err := i.svc.DeleteReplicationGroup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ElasticacheReplicationGroup) String() string {
+	return *i.groupID
+}


### PR DESCRIPTION
Adds an `ElasticacheReplicationGroup` resource. There is some overlap between this resource and the `ElasticacheCacheCluster` resource in that a replication group consists of multiple cache clusters. The problem though is that cache clusters that are part of a replication group aren't being deleted on their own, due to errors similar to the following:
```
InvalidCacheClusterState: Cache cluster transactions-001 is serving as primary for replication group transactions and cannot be deleted. To delete the entire replication group, use DeleteReplicationGroup.
--
  | status code: 400, request id: eb3f1c2e-c23f-11e8-a902-65beaf280fb2
```