### PR TITLE
Add IAMGroupPolicy resource

### DIFF
--- a/resources/iam-group-policies.go
+++ b/resources/iam-group-policies.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+type IAMGroupPolicy struct {
+	svc        *iam.IAM
+	policyName string
+	groupName  string
+}
+
+func init() {
+	register("IAMGroupPolicy", ListIAMGroupPolicies)
+}
+
+func ListIAMGroupPolicies(sess *session.Session) ([]Resource, error) {
+	svc := iam.New(sess)
+
+	resp, err := svc.ListGroups(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, group := range resp.Groups {
+		resp, err := svc.ListGroupPolicies(
+			&iam.ListGroupPoliciesInput{
+				GroupName: group.GroupName,
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, pol := range resp.PolicyNames {
+			resources = append(resources, &IAMGroupPolicy{
+				svc:        svc,
+				policyName: *pol,
+				groupName:  *group.GroupName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (e *IAMGroupPolicy) Remove() error {
+	_, err := e.svc.DeleteGroupPolicy(
+		&iam.DeleteGroupPolicyInput{
+			PolicyName: &e.policyName,
+			GroupName:  &e.groupName,
+		})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *IAMGroupPolicy) String() string {
+	return fmt.Sprintf("%s -> %s", e.groupName, e.policyName)
+}


### PR DESCRIPTION
Adds a new resource for deleting IAM group inline policies. Without this resource, any IAM group with inline policies is not nuke-able:
```
global - IAMGroup - build.AdminRole - DeleteConflict: Cannot delete entity, must delete policies first.
--
  | status code: 409, request id: ecb65335-c23f-11e8-a1c3-132b0b63d06b
```