### PR TITLE
Add tags to more resources

### DIFF
--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -58,19 +58,28 @@ func (p Properties) Set(key string, value interface{}) Properties {
 }
 
 func (p Properties) SetTag(tagKey *string, tagValue interface{}) Properties {
+	return p.SetTagWithPrefix("", tagKey, tagValue)
+}
+
+func (p Properties) SetTagWithPrefix(prefix string, tagKey *string, tagValue interface{}) Properties {
 	if tagKey == nil {
 		return p
 	}
 
-	keyStr := *tagKey
+	keyStr := strings.TrimSpace(*tagKey)
+	prefix = strings.TrimSpace(prefix)
 
-	sanitizedTagKey := strings.Trim(keyStr, " ")
-	if sanitizedTagKey == "" {
+	if keyStr == "" {
 		return p
 	}
 
-	key := "tag:" + keyStr
-	return p.Set(key, tagValue)
+	if prefix != "" {
+		keyStr = fmt.Sprintf("%s:%s", prefix, keyStr)
+	}
+
+	keyStr = fmt.Sprintf("tag:%s", keyStr)
+
+	return p.Set(keyStr, tagValue)
 }
 
 func (p Properties) Get(key string) string {

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
@@ -59,6 +60,65 @@ func TestPropertiesEquals(t *testing.T) {
 				t.Errorf("Test Case reverse check failed. Want %t. Got %t.", !tc.result, tc.result)
 				t.Errorf("p1: %s", tc.p1.String())
 				t.Errorf("p2: %s", tc.p2.String())
+			}
+		})
+	}
+}
+
+func TestPropertiesSetTag(t *testing.T) {
+	cases := []struct {
+		name  string
+		key   *string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "string",
+			key:   aws.String("name"),
+			value: "blubber",
+			want:  `[tag:name: "blubber"]`,
+		},
+		{
+			name:  "string_ptr",
+			key:   aws.String("name"),
+			value: aws.String("blubber"),
+			want:  `[tag:name: "blubber"]`,
+		},
+		{
+			name:  "int",
+			key:   aws.String("int"),
+			value: 42,
+			want:  `[tag:int: "42"]`,
+		},
+		{
+			name:  "nil",
+			key:   aws.String("nothing"),
+			value: nil,
+			want:  `[]`,
+		},
+		{
+			name:  "empty_key",
+			key:   aws.String(""),
+			value: "empty",
+			want:  `[]`,
+		},
+		{
+			name:  "nil_key",
+			key:   nil,
+			value: "empty",
+			want:  `[]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := types.NewProperties()
+
+			p.SetTag(tc.key, tc.value)
+			have := p.String()
+
+			if tc.want != have {
+				t.Errorf("'%s' != '%s'", tc.want, have)
 			}
 		})
 	}

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -123,3 +123,41 @@ func TestPropertiesSetTag(t *testing.T) {
 		})
 	}
 }
+
+func TestPropertiesSetTagWithPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		key    *string
+		value  interface{}
+		want   string
+	}{
+		{
+			name:   "empty",
+			prefix: "",
+			key:    aws.String("name"),
+			value:  "blubber",
+			want:   `[tag:name: "blubber"]`,
+		},
+		{
+			name:   "nonempty",
+			prefix: "bish",
+			key:    aws.String("bash"),
+			value:  "bosh",
+			want:   `[tag:bish:bash: "bosh"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := types.NewProperties()
+
+			p.SetTagWithPrefix(tc.prefix, tc.key, tc.value)
+			have := p.String()
+
+			if tc.want != have {
+				t.Errorf("'%s' != '%s'", tc.want, have)
+			}
+		})
+	}
+}

--- a/resources/ec2-internet-gateway-attachments.go
+++ b/resources/ec2-internet-gateway-attachments.go
@@ -12,8 +12,8 @@ import (
 type EC2InternetGatewayAttachment struct {
 	svc     *ec2.EC2
 	vpcId   *string
+	vpcTags []*ec2.Tag
 	igwId   *string
-	// The IGW is more specific than the VPC so we use those tags
 	igwTags []*ec2.Tag
 }
 
@@ -49,6 +49,7 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 			resources = append(resources, &EC2InternetGatewayAttachment{
 				svc:     svc,
 				vpcId:   vpc.VpcId,
+				vpcTags: vpc.Tags,
 				igwId:   igw.InternetGatewayId,
 				igwTags: igw.Tags,
 			})
@@ -75,7 +76,10 @@ func (e *EC2InternetGatewayAttachment) Remove() error {
 func (e *EC2InternetGatewayAttachment) Properties() types.Properties {
 	properties := types.NewProperties()
 	for _, tagValue := range e.igwTags {
-		properties.SetTag(tagValue.Key, tagValue.Value)
+		properties.SetTagWithPrefix("igw", tagValue.Key, tagValue.Value)
+	}
+	for _, tagValue := range e.vpcTags {
+		properties.SetTagWithPrefix("vpc", tagValue.Key, tagValue.Value)
 	}
 	return properties
 }

--- a/resources/ec2-internet-gateway-attachments.go
+++ b/resources/ec2-internet-gateway-attachments.go
@@ -6,12 +6,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2InternetGatewayAttachment struct {
-	svc   *ec2.EC2
-	vpcId *string
-	igwId *string
+	svc     *ec2.EC2
+	vpcId   *string
+	igwId   *string
+	// The IGW is more specific than the VPC so we use those tags
+	igwTags []*ec2.Tag
 }
 
 func init() {
@@ -30,7 +33,7 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 	for _, vpc := range resp.Vpcs {
 		params := &ec2.DescribeInternetGatewaysInput{
 			Filters: []*ec2.Filter{
-				&ec2.Filter{
+				{
 					Name:   aws.String("attachment.vpc-id"),
 					Values: []*string{vpc.VpcId},
 				},
@@ -42,11 +45,12 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 			return nil, err
 		}
 
-		for _, out := range resp.InternetGateways {
+		for _, igw := range resp.InternetGateways {
 			resources = append(resources, &EC2InternetGatewayAttachment{
-				svc:   svc,
-				vpcId: vpc.VpcId,
-				igwId: out.InternetGatewayId,
+				svc:     svc,
+				vpcId:   vpc.VpcId,
+				igwId:   igw.InternetGatewayId,
+				igwTags: igw.Tags,
 			})
 		}
 	}
@@ -66,6 +70,14 @@ func (e *EC2InternetGatewayAttachment) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *EC2InternetGatewayAttachment) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.igwTags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (e *EC2InternetGatewayAttachment) String() string {

--- a/resources/ec2-internet-gateways.go
+++ b/resources/ec2-internet-gateways.go
@@ -3,11 +3,12 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2InternetGateway struct {
 	svc *ec2.EC2
-	id  *string
+	igw *ec2.InternetGateway
 }
 
 func init() {
@@ -23,10 +24,10 @@ func ListEC2InternetGateways(sess *session.Session) ([]Resource, error) {
 	}
 
 	resources := make([]Resource, 0)
-	for _, out := range resp.InternetGateways {
+	for _, igw := range resp.InternetGateways {
 		resources = append(resources, &EC2InternetGateway{
 			svc: svc,
-			id:  out.InternetGatewayId,
+			igw: igw,
 		})
 	}
 
@@ -35,7 +36,7 @@ func ListEC2InternetGateways(sess *session.Session) ([]Resource, error) {
 
 func (e *EC2InternetGateway) Remove() error {
 	params := &ec2.DeleteInternetGatewayInput{
-		InternetGatewayId: e.id,
+		InternetGatewayId: e.igw.InternetGatewayId,
 	}
 
 	_, err := e.svc.DeleteInternetGateway(params)
@@ -46,6 +47,14 @@ func (e *EC2InternetGateway) Remove() error {
 	return nil
 }
 
+func (e *EC2InternetGateway) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.igw.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
+}
+
 func (e *EC2InternetGateway) String() string {
-	return *e.id
+	return *e.igw.InternetGatewayId
 }

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -3,11 +3,12 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2RouteTable struct {
-	svc *ec2.EC2
-	id  *string
+	svc        *ec2.EC2
+	routeTable *ec2.RouteTable
 }
 
 func init() {
@@ -25,8 +26,8 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, out := range resp.RouteTables {
 		resources = append(resources, &EC2RouteTable{
-			svc: svc,
-			id:  out.RouteTableId,
+			svc:        svc,
+			routeTable: out,
 		})
 	}
 
@@ -35,7 +36,7 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 
 func (e *EC2RouteTable) Remove() error {
 	params := &ec2.DeleteRouteTableInput{
-		RouteTableId: e.id,
+		RouteTableId: e.routeTable.RouteTableId,
 	}
 
 	_, err := e.svc.DeleteRouteTable(params)
@@ -46,6 +47,14 @@ func (e *EC2RouteTable) Remove() error {
 	return nil
 }
 
+func (e *EC2RouteTable) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.routeTable.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
+}
+
 func (e *EC2RouteTable) String() string {
-	return *e.id
+	return *e.routeTable.RouteTableId
 }

--- a/resources/ec2-vpcEndpoint.go
+++ b/resources/ec2-vpcEndpoint.go
@@ -3,11 +3,14 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 type EC2VPCEndpoint struct {
-	svc *ec2.EC2
-	id  *string
+	svc     *ec2.EC2
+	id      *string
+	vpcTags []*ec2.Tag
 }
 
 func init() {
@@ -17,17 +20,34 @@ func init() {
 func ListEC2VPCEndpoints(sess *session.Session) ([]Resource, error) {
 	svc := ec2.New(sess)
 
-	resp, err := svc.DescribeVpcEndpoints(nil)
+	resp, err := svc.DescribeVpcs(nil)
 	if err != nil {
 		return nil, err
 	}
 
 	resources := make([]Resource, 0)
-	for _, vpcEndpoint := range resp.VpcEndpoints {
-		resources = append(resources, &EC2VPCEndpoint{
-			svc: svc,
-			id:  vpcEndpoint.VpcEndpointId,
-		})
+	for _, vpc := range resp.Vpcs {
+		params := &ec2.DescribeVpcEndpointsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: []*string{vpc.VpcId},
+				},
+			},
+		}
+
+		resp, err := svc.DescribeVpcEndpoints(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, vpcEndpoint := range resp.VpcEndpoints {
+			resources = append(resources, &EC2VPCEndpoint{
+				svc:  svc,
+				id:   vpcEndpoint.VpcEndpointId,
+				vpcTags: vpc.Tags,
+			})
+		}
 	}
 
 	return resources, nil
@@ -44,6 +64,14 @@ func (endpoint *EC2VPCEndpoint) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *EC2VPCEndpoint) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.vpcTags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (endpoint *EC2VPCEndpoint) String() string {

--- a/resources/ec2-vpn-gateway-attachments.go
+++ b/resources/ec2-vpn-gateway-attachments.go
@@ -5,13 +5,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2VPNGatewayAttachment struct {
-	svc   *ec2.EC2
-	vpcId string
-	vpnId string
-	state string
+	svc     *ec2.EC2
+	vpcId   string
+	vpnId   string
+	state   string
+	// The VGW is more specific than the VPC so we use those tags
+	vgwTags []*ec2.Tag
 }
 
 func init() {
@@ -21,20 +25,33 @@ func init() {
 func ListEC2VPNGatewayAttachments(sess *session.Session) ([]Resource, error) {
 	svc := ec2.New(sess)
 
-	resp, err := svc.DescribeVpnGateways(nil)
+	resp, err := svc.DescribeVpcs(nil)
 	if err != nil {
 		return nil, err
 	}
 
 	resources := make([]Resource, 0)
+	for _, vpc := range resp.Vpcs {
+		params := &ec2.DescribeVpnGatewaysInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("attachment.vpc-id"),
+					Values: []*string{vpc.VpcId},
+				},
+			},
+		}
 
-	for _, vgw := range resp.VpnGateways {
-		for _, att := range vgw.VpcAttachments {
+		resp, err := svc.DescribeVpnGateways(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, vgw := range resp.VpnGateways {
 			resources = append(resources, &EC2VPNGatewayAttachment{
-				svc:   svc,
-				vpcId: *att.VpcId,
-				vpnId: *vgw.VpnGatewayId,
-				state: *att.State,
+				svc:     svc,
+				vpcId:   *vpc.VpcId,
+				vpnId:   *vgw.VpnGatewayId,
+				vgwTags: vgw.Tags,
 			})
 		}
 	}
@@ -61,6 +78,14 @@ func (v *EC2VPNGatewayAttachment) Remove() error {
 	}
 
 	return nil
+}
+
+func (v *EC2VPNGatewayAttachment) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range v.vgwTags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (v *EC2VPNGatewayAttachment) String() string {

--- a/resources/elb-elb.go
+++ b/resources/elb-elb.go
@@ -3,11 +3,13 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type ELBLoadBalancer struct {
 	svc  *elb.ELB
 	name *string
+	tags []*elb.Tag
 }
 
 func init() {
@@ -17,19 +19,32 @@ func init() {
 func ListELBLoadBalancers(sess *session.Session) ([]Resource, error) {
 	svc := elb.New(sess)
 
-	resp, err := svc.DescribeLoadBalancers(nil)
+	elbResp, err := svc.DescribeLoadBalancers(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tagRequestELBNames []*string
+	for _, elb := range elbResp.LoadBalancerDescriptions {
+		tagRequestELBNames = append(tagRequestELBNames, elb.LoadBalancerName)
+	}
+
+	// Tags for ELBs need to be fetched separately
+	tagResp, err := svc.DescribeTags(&elb.DescribeTagsInput{
+		LoadBalancerNames: tagRequestELBNames,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	resources := make([]Resource, 0)
-	for _, elb := range resp.LoadBalancerDescriptions {
+	for _, elbTagInfo := range tagResp.TagDescriptions {
 		resources = append(resources, &ELBLoadBalancer{
 			svc:  svc,
-			name: elb.LoadBalancerName,
+			name: elbTagInfo.LoadBalancerName,
+			tags: elbTagInfo.Tags,
 		})
 	}
-
 	return resources, nil
 }
 
@@ -44,6 +59,14 @@ func (e *ELBLoadBalancer) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *ELBLoadBalancer) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (e *ELBLoadBalancer) String() string {

--- a/resources/elbv2-alb.go
+++ b/resources/elbv2-alb.go
@@ -3,12 +3,14 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type ELBv2LoadBalancer struct {
 	svc  *elbv2.ELBV2
 	name *string
 	arn  *string
+	tags []*elbv2.Tag
 }
 
 func init() {
@@ -18,20 +20,46 @@ func init() {
 func ListELBv2LoadBalancers(sess *session.Session) ([]Resource, error) {
 	svc := elbv2.New(sess)
 
-	resp, err := svc.DescribeLoadBalancers(nil)
+	elbResp, err := svc.DescribeLoadBalancers(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resources := make([]Resource, 0)
-	for _, elbv2 := range resp.LoadBalancers {
-		resources = append(resources, &ELBv2LoadBalancer{
-			svc:  svc,
-			name: elbv2.LoadBalancerName,
-			arn:  elbv2.LoadBalancerArn,
-		})
+	var tagReqELBv2ARNs []*string
+	ELBv2ArnToName := make(map[string]*string)
+	for _, elbv2 := range elbResp.LoadBalancers {
+		tagReqELBv2ARNs = append(tagReqELBv2ARNs, elbv2.LoadBalancerArn)
+		ELBv2ArnToName[*elbv2.LoadBalancerArn] = elbv2.LoadBalancerName
 	}
 
+	// Tags for ELBv2s need to be fetched separately
+	// We can only specify up to 20 in a single call
+	// See: https://github.com/aws/aws-sdk-go/blob/0e8c61841163762f870f6976775800ded4a789b0/service/elbv2/api.go#L5398
+	resources := make([]Resource, 0)
+	for len(tagReqELBv2ARNs) > 0 {
+		requestElements := len(tagReqELBv2ARNs)
+		if requestElements > 20 {
+			requestElements = 20
+		}
+
+		tagResp, err := svc.DescribeTags(&elbv2.DescribeTagsInput{
+			ResourceArns: tagReqELBv2ARNs[:requestElements],
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, elbv2TagInfo := range tagResp.TagDescriptions {
+			resources = append(resources, &ELBv2LoadBalancer{
+				svc:  svc,
+				name: ELBv2ArnToName[*elbv2TagInfo.ResourceArn],
+				arn:  elbv2TagInfo.ResourceArn,
+				tags: elbv2TagInfo.Tags,
+			})
+		}
+
+		// Remove the elements that were queried
+		tagReqELBv2ARNs = tagReqELBv2ARNs[requestElements:]
+	}
 	return resources, nil
 }
 
@@ -46,6 +74,14 @@ func (e *ELBv2LoadBalancer) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *ELBv2LoadBalancer) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (e *ELBv2LoadBalancer) String() string {

--- a/resources/iam-instance-profiles.go
+++ b/resources/iam-instance-profiles.go
@@ -16,18 +16,27 @@ func init() {
 
 func ListIAMInstanceProfiles(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
-
-	resp, err := svc.ListInstanceProfiles(nil)
-	if err != nil {
-		return nil, err
-	}
-
+	params := &iam.ListInstanceProfilesInput{}
 	resources := make([]Resource, 0)
-	for _, out := range resp.InstanceProfiles {
-		resources = append(resources, &IAMInstanceProfile{
-			svc:  svc,
-			name: *out.InstanceProfileName,
-		})
+
+	for {
+		resp, err := svc.ListInstanceProfiles(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, out := range resp.InstanceProfiles {
+			resources = append(resources, &IAMInstanceProfile{
+				svc:  svc,
+				name: *out.InstanceProfileName,
+			})
+		}
+
+		if *resp.IsTruncated == false {
+			break
+		}
+
+		params.Marker = resp.Marker
 	}
 
 	return resources, nil

--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -17,20 +17,29 @@ func init() {
 
 func ListIAMPolicies(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
-
-	resp, err := svc.ListPolicies(&iam.ListPoliciesInput{
+	params := &iam.ListPoliciesInput{
 		Scope: aws.String("Local"),
-	})
-	if err != nil {
-		return nil, err
 	}
-
 	resources := make([]Resource, 0)
-	for _, out := range resp.Policies {
-		resources = append(resources, &IAMPolicy{
-			svc: svc,
-			arn: *out.Arn,
-		})
+
+	for {
+		resp, err := svc.ListPolicies(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, out := range resp.Policies {
+			resources = append(resources, &IAMPolicy{
+				svc: svc,
+				arn: *out.Arn,
+			})
+		}
+
+		if *resp.IsTruncated == false {
+			break
+		}
+
+		params.Marker = resp.Marker
 	}
 
 	return resources, nil

--- a/resources/iam-role-policy.go
+++ b/resources/iam-role-policy.go
@@ -19,28 +19,47 @@ func init() {
 
 func ListIAMRolePolicies(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
-
-	roles, err := svc.ListRoles(nil)
-	if err != nil {
-		return nil, err
-	}
-
+	roleParams := &iam.ListRolesInput{}
 	resources := make([]Resource, 0)
-	for _, role := range roles.Roles {
-		policies, err := svc.ListRolePolicies(&iam.ListRolePoliciesInput{
-			RoleName: role.RoleName,
-		})
+
+	for {
+		roles, err := svc.ListRoles(roleParams)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, policyName := range policies.PolicyNames {
-			resources = append(resources, &IAMRolePolicy{
-				svc:        svc,
-				policyName: *policyName,
-				roleName:   *role.RoleName,
-			})
+		for _, role := range roles.Roles {
+			polParams := &iam.ListRolePoliciesInput{
+				RoleName: role.RoleName,
+			}
+
+			for {
+				policies, err := svc.ListRolePolicies(polParams)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, policyName := range policies.PolicyNames {
+					resources = append(resources, &IAMRolePolicy{
+						svc:        svc,
+						policyName: *policyName,
+						roleName:   *role.RoleName,
+					})
+				}
+
+				if *policies.IsTruncated == false {
+					break
+				}
+
+				polParams.Marker = policies.Marker
+			}
 		}
+
+		if *roles.IsTruncated == false {
+			break
+		}
+
+		roleParams.Marker = roles.Marker
 	}
 
 	return resources, nil


### PR DESCRIPTION
I've mostly copied what was done over in #237 and extended it to resource types that I need to filter based on tag values.

There were two resource types that I've made a potentially controversial decision about: `EC2InternetGatewayAttachment`, `EC2VPNGatewayAttachment`, and `EC2VPCEndpoint`. For `EC2InternetGatewayAttachment` and `EC2VPNGatewayAttachment` I have chosen to inherit the tags from the Internet/VPN Gateway as a gateway would be more likely to have more specific tags than the VPC it lives in. If we should include both sets of tags I'm also fine with that, I just can't think of a good way to display both with the current key/value pairing.

For EC2VPCEndpoint I've just inherited the tags from the containing VPC.