### PR TITLE
Allow nuking of SAML and OpenIdConnect Identity Provider

### DIFF
--- a/resources/iam-open-id-connect-provider.go
+++ b/resources/iam-open-id-connect-provider.go
@@ -1,0 +1,50 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+type IAMOpenIDConnectProvider struct {
+	svc *iam.IAM
+	arn string
+}
+
+func init() {
+	register("IAMOpenIDConnectProvider", ListIAMOpenIDConnectProvider)
+}
+
+func ListIAMOpenIDConnectProvider(sess *session.Session) ([]Resource, error) {
+	svc := iam.New(sess)
+	params := &iam.ListOpenIDConnectProvidersInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListOpenIDConnectProviders(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, out := range resp.OpenIDConnectProviderList {
+		resources = append(resources, &IAMOpenIDConnectProvider{
+			svc: svc,
+			arn: *out.Arn,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *IAMOpenIDConnectProvider) Remove() error {
+	_, err := e.svc.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: &e.arn,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *IAMOpenIDConnectProvider) String() string {
+	return e.arn
+}

--- a/resources/iam-saml-provider.go
+++ b/resources/iam-saml-provider.go
@@ -1,0 +1,50 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+type IAMSAMLProvider struct {
+	svc *iam.IAM
+	arn string
+}
+
+func init() {
+	register("IAMSAMLProvider", ListIAMSAMLProvider)
+}
+
+func ListIAMSAMLProvider(sess *session.Session) ([]Resource, error) {
+	svc := iam.New(sess)
+	params := &iam.ListSAMLProvidersInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListSAMLProviders(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, out := range resp.SAMLProviderList {
+		resources = append(resources, &IAMSAMLProvider{
+			svc: svc,
+			arn: *out.Arn,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *IAMSAMLProvider) Remove() error {
+	_, err := e.svc.DeleteSAMLProvider(&iam.DeleteSAMLProviderInput{
+		SAMLProviderArn: &e.arn,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *IAMSAMLProvider) String() string {
+	return e.arn
+}


### PR DESCRIPTION
Added the capability to nuke specific SAML and OpenIdConnect Identity Providers.

This has been tested using ADFS within our test infrastructure. 
 