### PR TITLE
Fix for using DynamoDB with reserved keywords

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -16,7 +16,7 @@ BUILD_FLAGS=-ldflags "\
 
 BUILD_ARTIFACT=$(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)
 
-GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
 GOPKGS=$(shell glide nv)
 
 default: build

--- a/resources/dynamodb-items.go
+++ b/resources/dynamodb-items.go
@@ -45,10 +45,18 @@ func ListDynamoDBItems(sess *session.Session) ([]Resource, error) {
 			return nil, descErr
 		}
 
+		var params *dynamodb.ScanInput
+
 		key := *descResp.Table.KeySchema[0].AttributeName
-		params := &dynamodb.ScanInput{
-			TableName:            &dynamoTable.id,
-			ProjectionExpression: aws.String(key),
+		if key == "hash" {
+			params = &dynamodb.ScanInput{
+				TableName:            &dynamoTable.id,
+			}
+		} else {
+			params = &dynamodb.ScanInput{
+				TableName:            &dynamoTable.id,
+				ProjectionExpression: aws.String(key),
+			}
 		}
 
 		scanResp, scanErr := svc.Scan(params)

--- a/resources/dynamodb-items.go
+++ b/resources/dynamodb-items.go
@@ -48,6 +48,8 @@ func ListDynamoDBItems(sess *session.Session) ([]Resource, error) {
 		var params *dynamodb.ScanInput
 
 		key := *descResp.Table.KeySchema[0].AttributeName
+		// Don't use ProjectionExpression in case it is "hash", because it
+		// is a reserved keyword and creates errors.
 		if key == "hash" {
 			params = &dynamodb.ScanInput{
 				TableName:            &dynamoTable.id,


### PR DESCRIPTION
Our DynamoDB had a primary key called `hash`. This created an error because it is a reserved keyword, so I created a workaround for this specific case.

@rebuy-de/prp-aws-nuke Please review.