### PR TITLE
New resource CognitoUserPoolDomain

### DIFF
--- a/resources/cognito-userpools.go
+++ b/resources/cognito-userpools.go
@@ -7,10 +7,9 @@ import (
 )
 
 type CognitoUserPool struct {
-	svc    *cognitoidentityprovider.CognitoIdentityProvider
-	name   *string
-	id     *string
-	domain *string
+	svc  *cognitoidentityprovider.CognitoIdentityProvider
+	name *string
+	id   *string
 }
 
 func init() {
@@ -32,23 +31,10 @@ func ListCognitoUserPools(sess *session.Session) ([]Resource, error) {
 		}
 
 		for _, pool := range output.UserPools {
-			describeParams := &cognitoidentityprovider.DescribeUserPoolInput{
-				UserPoolId: pool.Id,
-			}
-			userpool, err := svc.DescribeUserPool(describeParams)
-			if err != nil {
-				return nil, err
-			}
-			domain := ""
-			if userpool.UserPool.Domain != nil {
-				domain = *userpool.UserPool.Domain
-			}
-
 			resources = append(resources, &CognitoUserPool{
-				svc:    svc,
-				name:   pool.Name,
-				id:     pool.Id,
-				domain: &domain,
+				svc:  svc,
+				name: pool.Name,
+				id:   pool.Id,
 			})
 		}
 
@@ -63,16 +49,6 @@ func ListCognitoUserPools(sess *session.Session) ([]Resource, error) {
 }
 
 func (f *CognitoUserPool) Remove() error {
-	if *f.domain != "" {
-		domainParams := &cognitoidentityprovider.DeleteUserPoolDomainInput{
-			Domain:     f.domain,
-			UserPoolId: f.id,
-		}
-		_, err := f.svc.DeleteUserPoolDomain(domainParams)
-		if err != nil {
-			return err
-		}
-	}
 
 	_, err := f.svc.DeleteUserPool(&cognitoidentityprovider.DeleteUserPoolInput{
 		UserPoolId: f.id,


### PR DESCRIPTION
I was getting an error when trying to delete CognitoUserPools in our environment:

```
CognitoUserPool - foo - InvalidParameterException: User pool cannot be deleted. It has a domain configured that should be deleted first.
	status code: 400
```

This will describe each user pool, since that's the only way to grab the domain if it exists, and store that domain in the struct. On remove, if the domain is present, it removes that first. I tested this on my end with UserPools with and without a domain and it functions as expected. 