### PR TITLE
Added IAMServiceSpecificCredentials resource

### DIFF
--- a/resources/iam-service-specific-credentials.go
+++ b/resources/iam-service-specific-credentials.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/sirupsen/logrus"
+)
+
+type IAMServiceSpecificCredential struct {
+	svc         *iam.IAM
+	name        string
+	serviceName string
+	id          string
+	userName    string
+}
+
+func init() {
+	register("IAMServiceSpecificCredential", ListServiceSpecificCredentials)
+}
+
+func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
+	svc := iam.New(sess)
+
+	users, usersErr := ListIAMUsers(sess)
+	if usersErr != nil {
+		return nil, usersErr
+	}
+
+	resources := make([]Resource, 0)
+	for _, userResource := range users {
+		user, ok := userResource.(*IAMUser)
+		if !ok {
+			logrus.Errorf("Unable to cast IAMUser.")
+			continue
+		}
+		params := &iam.ListServiceSpecificCredentialsInput{
+			UserName: &user.name,
+		}
+		serviceCredentials, err := svc.ListServiceSpecificCredentials(params)
+		if err != nil {
+			return nil, err
+		}
+
+		// ServiceSpecificCredentials comes back as an array
+		// so loop through that here
+		for _, credential := range serviceCredentials.ServiceSpecificCredentials {
+			resources = append(resources, &IAMServiceSpecificCredential{
+				svc:         svc,
+				name:        *credential.ServiceUserName,
+				serviceName: *credential.ServiceName,
+				id:          *credential.ServiceSpecificCredentialId,
+				userName:    user.name,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (e *IAMServiceSpecificCredential) Remove() error {
+	params := &iam.DeleteServiceSpecificCredentialInput{
+		ServiceSpecificCredentialId: &e.id,
+		UserName:                    &e.userName,
+	}
+	_, err := e.svc.DeleteServiceSpecificCredential(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *IAMServiceSpecificCredential) String() string {
+	return e.userName + " -> [" + e.serviceName + "] " + e.name
+}

--- a/resources/iam-service-specific-credentials.go
+++ b/resources/iam-service-specific-credentials.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,8 +42,6 @@ func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
 			return nil, err
 		}
 
-		// ServiceSpecificCredentials comes back as an array
-		// so loop through that here
 		for _, credential := range serviceCredentials.ServiceSpecificCredentials {
 			resources = append(resources, &IAMServiceSpecificCredential{
 				svc:         svc,
@@ -69,6 +68,13 @@ func (e *IAMServiceSpecificCredential) Remove() error {
 	return nil
 }
 
+func (e *IAMServiceSpecificCredential) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ServiceName", e.serviceName)
+	properties.Set("ID", e.id)
+	return properties
+}
+
 func (e *IAMServiceSpecificCredential) String() string {
-	return e.userName + " -> [" + e.serviceName + "] " + e.name
+	return e.userName + " -> " + e.name
 }


### PR DESCRIPTION
I was hitting an error with the nuker involving IAM user dependencies:

```
global - IAMUser - test - DeleteConflict: Cannot delete entity, must remove referenced objects first.
	status code: 409
```
This is due to service specific credentials being attached to the user that need to be deleted first. I have added a new resource called IAMServiceSpecificCredential which gathers all of these keys from IAM users. 

I included the credential's service (gathered from the Describe api call) to include in the nuker output. I think codecommit is the only service right now but I thought being verbose in the output would be good in case they add more services in the future. Output will be the following in `iam-user -> [cred-service] service-credential-name` format.
```
global - IAMServiceSpecificCredential - test -> [codecommit.amazonaws.com] test-at-123456789012 - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.
```