### PR TITLE
Added resource EC2VPCEndpointServiceConfiguration

### DIFF
--- a/resources/ec2-vpc-endpoint-service-configurations.go
+++ b/resources/ec2-vpc-endpoint-service-configurations.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type EC2VPCEndpointServiceConfiguration struct {
+	svc  *ec2.EC2
+	id   *string
+	name *string
+}
+
+func init() {
+	register("EC2VPCEndpointServiceConfiguration", ListEC2VPCEndpointServiceConfigurations)
+}
+
+func ListEC2VPCEndpointServiceConfigurations(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+
+	resp, err := svc.DescribeVpcEndpointServiceConfigurations(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, serviceConfig := range resp.ServiceConfigurations {
+		resources = append(resources, &EC2VPCEndpointServiceConfiguration{
+			svc:  svc,
+			id:   serviceConfig.ServiceId,
+			name: serviceConfig.ServiceName,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *EC2VPCEndpointServiceConfiguration) Remove() error {
+	params := &ec2.DeleteVpcEndpointServiceConfigurationsInput{
+		ServiceIds: []*string{e.id},
+	}
+
+	_, err := e.svc.DeleteVpcEndpointServiceConfigurations(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *EC2VPCEndpointServiceConfiguration) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", e.name)
+	return properties
+}
+
+func (e *EC2VPCEndpointServiceConfiguration) String() string {
+	return *e.id
+}


### PR DESCRIPTION
I have added a new resource EC2VPCEndpointServiceConfiguration that will support private links within the VPC. These are different from the VPC Endpoints which there is already a resource. I tried to mimic the EC2VPCEndpoint resource as much as possible but just wanted to note that filtering by `vpc-id` is not supported in the [DescribeVpcEndpointServiceConfigurations API call](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcEndpointServiceConfigurations.html). This does mean that VPC filters on the nuke configuration will not exclude this resource, let me know if that's an issue and I can try and figure out a work around. 

The resource name is quite long but I wanted to stay consistent with the project and the APIs. Let me know if you have any alternative suggestions.

This also fixes the issue where NLBs are tied to a private link and unable to be deleted:

```
us-east-1 - ELBv2 - foo-nlb - [] - ResourceInUse: Load balancer 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/foo-nlb/123456' cannot be deleted because it is currently associated with another service
	status code: 400
us-east-1 - ELBv2TargetGroup - foo-tg - [] - ResourceInUse: Target group 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/foo-tg/123456' is currently in use by a listener or a rule
	status code: 400
```

I tied the name property in with the resource as well so the output will look similar to the following: 

```
us-east-2 - EC2VPCEndpointServiceConfiguration - vpce-svc-01f2ce46fabd7 - [Name: "com.amazonaws.vpce.us-east-2.vpce-svc-01f2ce46fabd7"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.
```