### PR TITLE
Add resources for FSx filesystems and backups

### DIFF
--- a/resources/fsx-backups.go
+++ b/resources/fsx-backups.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type FSxBackup struct {
+	svc    *fsx.FSx
+	backup *fsx.Backup
+}
+
+func init() {
+	register("FSxBackup", ListFSxBackups)
+}
+
+func ListFSxBackups(sess *session.Session) ([]Resource, error) {
+	svc := fsx.New(sess)
+	resources := []Resource{}
+
+	params := &fsx.DescribeBackupsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		resp, err := svc.DescribeBackups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, backup := range resp.Backups {
+			resources = append(resources, &FSxBackup{
+				svc:    svc,
+				backup: backup,
+			})
+		}
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+	return resources, nil
+}
+
+func (f *FSxBackup) Remove() error {
+	_, err := f.svc.DeleteBackup(&fsx.DeleteBackupInput{
+		BackupId: f.backup.BackupId,
+	})
+
+	return err
+}
+
+func (f *FSxBackup) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range f.backup.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("Type", f.backup.Type)
+	return properties
+}
+
+func (f *FSxBackup) String() string {
+	return *f.backup.BackupId
+}

--- a/resources/fsx-filesystems.go
+++ b/resources/fsx-filesystems.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type FSxFileSystem struct {
+	svc        *fsx.FSx
+	filesystem *fsx.FileSystem
+}
+
+func init() {
+	register("FSxFileSystem", ListFSxFileSystems)
+}
+
+func ListFSxFileSystems(sess *session.Session) ([]Resource, error) {
+	svc := fsx.New(sess)
+	resources := []Resource{}
+
+	params := &fsx.DescribeFileSystemsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		resp, err := svc.DescribeFileSystems(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, filesystem := range resp.FileSystems {
+			resources = append(resources, &FSxFileSystem{
+				svc:        svc,
+				filesystem: filesystem,
+			})
+		}
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+	return resources, nil
+}
+
+func (f *FSxFileSystem) Remove() error {
+	_, err := f.svc.DeleteFileSystem(&fsx.DeleteFileSystemInput{
+		FileSystemId: f.filesystem.FileSystemId,
+	})
+
+	return err
+}
+
+func (f *FSxFileSystem) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range f.filesystem.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("Type", f.filesystem.FileSystemType)
+	return properties
+}
+
+func (f *FSxFileSystem) String() string {
+	return *f.filesystem.FileSystemId
+}


### PR DESCRIPTION
I have added two new resources to support FSx: FSxFileSystem and FSxBackup. Tags and the Type are being set in the properties. 

Output will be similar to the following:
```
us-east-2 - FSxBackup - backup-08fa7bdc34499d283 - [Type: "AUTOMATIC"] - would remove
us-east-2 - FSxBackup - backup-0425e8b5689f67c6d - [tag:Name: "pemcne-test-backup", Type: "USER_INITIATED"] - would remove
us-east-2 - FSxFileSystem - fs-0cdc6d27c6cebb7d8 - [tag:Name: "pemcne-test", Type: "LUSTRE"] - would remove
us-east-2 - FSxFileSystem - fs-00366030c6a1d9207 - [tag:Name: "pemcne-test", Type: "WINDOWS"] - would remove
Scan complete: 4 total, 4 nukeable, 0 filtered.
```