### PR TITLE
filter DAX default Subnet Group

### DIFF
--- a/resources/dax-subnetgroups.go
+++ b/resources/dax-subnetgroups.go
@@ -46,6 +46,13 @@ func ListDAXSubnetGroups(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
+func (f *DAXSubnetGroup) Filter() error {
+	if *f.subnetGroupName == "default" {
+		return fmt.Errorf("Cannot delete default DAX Subnet group")
+	}
+	return nil
+}
+
 func (f *DAXSubnetGroup) Remove() error {
 
 	_, err := f.svc.DeleteSubnetGroup(&dax.DeleteSubnetGroupInput{


### PR DESCRIPTION
Attempting to nuke DAX default subnet group yields the message:
`us-west-2 - DAXSubnetGroup - default - InvalidParameterValueException: default is reserved and cannot be modified.
	status code: 400, request id: ...`

This should filter out the default group.