### PR TITLE
Add 'DefaultForAz' property for subnets

### DIFF
--- a/resources/ec2-subnets.go
+++ b/resources/ec2-subnets.go
@@ -53,6 +53,7 @@ func (e *EC2Subnet) Properties() types.Properties {
 	for _, tagValue := range e.subnet.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
+	properties.Set("DefaultForAz", e.subnet.DefaultForAz)
 	return properties
 }
 


### PR DESCRIPTION
Similar to issue https://github.com/rebuy-de/aws-nuke/issues/188 (implemented in https://github.com/rebuy-de/aws-nuke/pull/198), which allowed for easy filtering of the default VPC, this does the same for default subnets.

You can use it like so:

```yaml
accounts:
  "1234567890":
    filters:
      EC2Subnet:
      - property: DefaultForAz
        value: "true"
```