### PR TITLE
Remove All attached MFA devices and SSH Public keys before removing an IAMUser

### DIFF
--- a/resources/iam-users.go
+++ b/resources/iam-users.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
@@ -34,13 +35,76 @@ func ListIAMUsers(sess *session.Session) ([]Resource, error) {
 }
 
 func (e *IAMUser) Remove() error {
-	_, err := e.svc.DeleteUser(&iam.DeleteUserInput{
+	err := e.RemoveAllMFADevices()
+	if err != nil {
+		return err
+	}
+
+	err = e.RemoveAllSSHPublicKeys()
+	if err != nil {
+		return err
+	}
+
+	_, err = e.svc.DeleteUser(&iam.DeleteUserInput{
 		UserName: &e.name,
 	})
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (e *IAMUser) RemoveAllMFADevices() error {
+	params := &iam.ListMFADevicesInput{
+		UserName: aws.String(e.name),
+	}
+
+	var devices []*iam.MFADevice
+	err := e.svc.ListMFADevicesPages(params,
+		func(page *iam.ListMFADevicesOutput, lastPage bool) bool {
+			devices = append(devices, page.MFADevices...)
+			return true
+		})
+
+	if err != nil {
+		return err
+	}
+	for _, device := range devices {
+		_, err := e.svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+			UserName:     device.UserName,
+			SerialNumber: device.SerialNumber,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *IAMUser) RemoveAllSSHPublicKeys() error {
+	params := &iam.ListSSHPublicKeysInput{
+		UserName: aws.String(e.name),
+	}
+	var keys []*iam.SSHPublicKeyMetadata
+	err := e.svc.ListSSHPublicKeysPages(params,
+		func(page *iam.ListSSHPublicKeysOutput, lastPage bool) bool {
+			keys = append(keys, page.SSHPublicKeys...)
+			return true
+		})
+
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		_, err := e.svc.DeleteSSHPublicKey(&iam.DeleteSSHPublicKeyInput{
+			UserName:       key.UserName,
+			SSHPublicKeyId: key.SSHPublicKeyId,
+		})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Updated IAMUser resource to:
detach all mfa devices attached to a given user
delete SSH public keys created to a given user
This is required to fully remove the IAM User, otherwise we get an error:
"DeleteConflict: Cannot delete entity, must remove referenced objects first. status code: 409"


