### PR TITLE
IoTPolicy fixes: Remove all attached targets and delete non default iot policy version s

### DIFF
--- a/resources/iam-user-mfa-attachment.go
+++ b/resources/iam-user-mfa-attachment.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type IAMUserMfaAttachment struct {
+	svc          *iam.IAM
+	userName     string
+	serialNumber string
+}
+
+func init() {
+	register("IAMUserMfaAttachment", ListIAMUserMfaAttachments)
+}
+
+func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
+	svc := iam.New(sess)
+
+	resp, err := svc.ListUsers(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, user := range resp.Users {
+		params := &iam.ListMFADevicesInput{
+			UserName: user.UserName,
+		}
+		resp, err := svc.ListMFADevices(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, device := range resp.MFADevices {
+			resources = append(resources, &IAMUserMfaAttachment{
+				svc:          svc,
+				userName:     *user.UserName,
+				serialNumber: *device.SerialNumber,
+			})
+		}
+		params.Marker = resp.Marker
+	}
+
+	return resources, nil
+}
+
+func (e *IAMUserMfaAttachment) Remove() error {
+	_, err := e.svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+		UserName:     &e.userName,
+		SerialNumber: &e.serialNumber,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *IAMUserMfaAttachment) Properties() types.Properties {
+	return types.NewProperties().
+		Set("UserName", e.userName).
+		Set("SerialNumber", e.serialNumber)
+}
+
+func (e *IAMUserMfaAttachment) String() string {
+	return fmt.Sprintf("%s -> %s", e.userName, e.serialNumber)
+}

--- a/resources/iam-user-mfa-attachment.go
+++ b/resources/iam-user-mfa-attachment.go
@@ -19,8 +19,6 @@ func init() {
 }
 
 func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
-	svc := iam.New(sess)
-
 	results, err := ListIAMUsers(sess)
 	if err != nil {
 		return nil, err
@@ -29,25 +27,39 @@ func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, resource := range results {
 		user := resource.(*IAMUser)
-
-		params := &iam.ListMFADevicesInput{
-			UserName: aws.String(user.name),
+		userMfaDevices, err := user.ListAttachedMFADevices()
+		if err != nil {
+			return nil, err
 		}
-		resp, err := svc.ListMFADevices(params)
+		resources = append(resources, userMfaDevices...)
+	}
+
+	return resources, nil
+}
+
+func (f *IAMUser) ListAttachedMFADevices() ([]Resource, error) {
+	resources := make([]Resource, 0)
+	params := &iam.ListMFADevicesInput{
+		UserName: aws.String(f.name),
+	}
+	for {
+		resp, err := f.svc.ListMFADevices(params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, device := range resp.MFADevices {
 			resources = append(resources, &IAMUserMfaAttachment{
-				svc:          svc,
+				svc:          f.svc,
 				userName:     params.UserName,
 				serialNumber: *device.SerialNumber,
 			})
 		}
+		if params.Marker == nil {
+			break
+		}
 		params.Marker = resp.Marker
 	}
-
 	return resources, nil
 }
 

--- a/resources/iam-user-mfa-attachment.go
+++ b/resources/iam-user-mfa-attachment.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
@@ -9,7 +10,7 @@ import (
 
 type IAMUserMfaAttachment struct {
 	svc          *iam.IAM
-	userName     string
+	userName     *string
 	serialNumber string
 }
 
@@ -20,15 +21,17 @@ func init() {
 func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
 
-	resp, err := svc.ListUsers(nil)
+	results, err := ListIAMUsers(sess)
 	if err != nil {
 		return nil, err
 	}
 
 	resources := make([]Resource, 0)
-	for _, user := range resp.Users {
+	for _, resource := range results {
+		user := resource.(*IAMUser)
+
 		params := &iam.ListMFADevicesInput{
-			UserName: user.UserName,
+			UserName: aws.String(user.name),
 		}
 		resp, err := svc.ListMFADevices(params)
 		if err != nil {
@@ -38,7 +41,7 @@ func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
 		for _, device := range resp.MFADevices {
 			resources = append(resources, &IAMUserMfaAttachment{
 				svc:          svc,
-				userName:     *user.UserName,
+				userName:     params.UserName,
 				serialNumber: *device.SerialNumber,
 			})
 		}
@@ -50,7 +53,7 @@ func ListIAMUserMfaAttachments(sess *session.Session) ([]Resource, error) {
 
 func (e *IAMUserMfaAttachment) Remove() error {
 	_, err := e.svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
-		UserName:     &e.userName,
+		UserName:     e.userName,
 		SerialNumber: &e.serialNumber,
 	})
 	if err != nil {
@@ -67,5 +70,5 @@ func (e *IAMUserMfaAttachment) Properties() types.Properties {
 }
 
 func (e *IAMUserMfaAttachment) String() string {
-	return fmt.Sprintf("%s -> %s", e.userName, e.serialNumber)
+	return fmt.Sprintf("%s -> %s", *e.userName, e.serialNumber)
 }

--- a/resources/iam-users.go
+++ b/resources/iam-users.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
@@ -34,13 +35,76 @@ func ListIAMUsers(sess *session.Session) ([]Resource, error) {
 }
 
 func (e *IAMUser) Remove() error {
-	_, err := e.svc.DeleteUser(&iam.DeleteUserInput{
+	err := e.RemoveAllMFADevices()
+	if err != nil {
+		return err
+	}
+
+	err = e.RemoveAllSSHPublicKeys()
+	if err != nil {
+		return err
+	}
+
+	_, err = e.svc.DeleteUser(&iam.DeleteUserInput{
 		UserName: &e.name,
 	})
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (e *IAMUser) RemoveAllMFADevices() error {
+	params := &iam.ListMFADevicesInput{
+		UserName: aws.String(e.name),
+	}
+
+	var devices []*iam.MFADevice
+	err := e.svc.ListMFADevicesPages(params,
+		func(page *iam.ListMFADevicesOutput, lastPage bool) bool {
+			devices = append(devices, page.MFADevices...)
+			return true
+		})
+
+	if err != nil {
+		return err
+	}
+	for _, device := range devices {
+		_, err := e.svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+			UserName:     device.UserName,
+			SerialNumber: device.SerialNumber,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *IAMUser) RemoveAllSSHPublicKeys() error {
+	params := &iam.ListSSHPublicKeysInput{
+		UserName: aws.String(e.name),
+	}
+	var keys []*iam.SSHPublicKeyMetadata
+	err := e.svc.ListSSHPublicKeysPages(params,
+		func(page *iam.ListSSHPublicKeysOutput, lastPage bool) bool {
+			keys = append(keys, page.SSHPublicKeys...)
+			return true
+		})
+
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		_, err := e.svc.DeleteSSHPublicKey(&iam.DeleteSSHPublicKeyInput{
+			UserName:       key.UserName,
+			SSHPublicKeyId: key.SSHPublicKeyId,
+		})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/resources/iot-certificates.go
+++ b/resources/iot-certificates.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iot"
 )
@@ -36,6 +37,10 @@ func ListIoTCertificates(sess *session.Session) ([]Resource, error) {
 }
 
 func (f *IoTCertificate) Remove() error {
+	f.svc.UpdateCertificate(&iot.UpdateCertificateInput{
+		CertificateId: f.ID,
+		NewStatus:     aws.String("INACTIVE"),
+	})
 
 	_, err := f.svc.DeleteCertificate(&iot.DeleteCertificateInput{
 		CertificateId: f.ID,

--- a/resources/iot-policies-principal-attachments.go
+++ b/resources/iot-policies-principal-attachments.go
@@ -1,0 +1,79 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iot"
+)
+
+type IoTPolicyPrincipalAttachments struct {
+	svc        *iot.IoT
+	policyName *string
+	principal  *string
+}
+
+func init() {
+	register("IoTPolicyPrincipalAttachments", ListIoTPolicyPrincipalAttachments)
+}
+
+func ListIoTPolicyPrincipalAttachments(sess *session.Session) ([]Resource, error) {
+	resources := []Resource{}
+
+	results, err := ListIoTPolicies(sess)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range results {
+		iotPolicy := resource.(*IoTPolicy)
+
+		targets, err := iotPolicy.ListPolicyTargets()
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, targets...)
+	}
+
+	return resources, nil
+}
+
+func (f *IoTPolicy) ListPolicyTargets() ([]Resource, error) {
+	resources := make([]Resource, 0)
+	params := &iot.ListTargetsForPolicyInput{
+		PolicyName: f.name,
+		PageSize:   aws.Int64(25),
+	}
+	for {
+		output, err := f.svc.ListTargetsForPolicy(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, target := range output.Targets {
+			resources = append(resources, &IoTPolicyPrincipalAttachments{
+				svc:        f.svc,
+				policyName: f.name,
+				principal:  target,
+			})
+		}
+		if output.NextMarker == nil {
+			break
+		}
+
+		params.Marker = output.NextMarker
+	}
+	return resources, nil
+}
+
+func (f *IoTPolicyPrincipalAttachments) Remove() error {
+	_, err := f.svc.DetachPrincipalPolicy(&iot.DetachPrincipalPolicyInput{
+		PolicyName: f.policyName,
+		Principal:  f.principal,
+	})
+	return err
+}
+
+func (f *IoTPolicyPrincipalAttachments) String() string {
+	return fmt.Sprintf("%s -> %s", *f.policyName, *f.principal)
+}

--- a/resources/iot-policies.go
+++ b/resources/iot-policies.go
@@ -44,41 +44,8 @@ func ListIoTPolicies(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func (f *IoTPolicy) DetachAllPrincipals() error {
-	params := &iot.ListTargetsForPolicyInput{
-		PolicyName: f.name,
-		PageSize:   aws.Int64(25),
-	}
-	for {
-		output, err := f.svc.ListTargetsForPolicy(params)
-		if err != nil {
-			return err
-		}
-
-		for _, target := range output.Targets {
-			_, err = f.svc.DetachPrincipalPolicy(&iot.DetachPrincipalPolicyInput{
-				PolicyName: f.name,
-				Principal:  target,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		if output.NextMarker == nil {
-			break
-		}
-
-		params.Marker = output.NextMarker
-	}
-	return nil
-}
-
 func (f *IoTPolicy) Remove() error {
-	err := f.DetachAllPrincipals()
-	if err != nil {
-		return err
-	}
-	_, err = f.svc.DeletePolicy(&iot.DeletePolicyInput{
+	_, err := f.svc.DeletePolicy(&iot.DeletePolicyInput{
 		PolicyName: f.name,
 	})
 

--- a/resources/iot-policies.go
+++ b/resources/iot-policies.go
@@ -44,9 +44,41 @@ func ListIoTPolicies(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func (f *IoTPolicy) Remove() error {
+func (f *IoTPolicy) DetachAllPrincipals() error {
+	params := &iot.ListTargetsForPolicyInput{
+		PolicyName: f.name,
+		PageSize:   aws.Int64(25),
+	}
+	for {
+		output, err := f.svc.ListTargetsForPolicy(params)
+		if err != nil {
+			return err
+		}
 
-	_, err := f.svc.DeletePolicy(&iot.DeletePolicyInput{
+		for _, target := range output.Targets {
+			_, err = f.svc.DetachPrincipalPolicy(&iot.DetachPrincipalPolicyInput{
+				PolicyName: f.name,
+				Principal:  target,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if output.NextMarker == nil {
+			break
+		}
+
+		params.Marker = output.NextMarker
+	}
+	return nil
+}
+
+func (f *IoTPolicy) Remove() error {
+	err := f.DetachAllPrincipals()
+	if err != nil {
+		return err
+	}
+	_, err = f.svc.DeletePolicy(&iot.DeletePolicyInput{
 		PolicyName: f.name,
 	})
 

--- a/resources/iot-policies.go
+++ b/resources/iot-policies.go
@@ -45,14 +45,95 @@ func ListIoTPolicies(sess *session.Session) ([]Resource, error) {
 }
 
 func (f *IoTPolicy) Remove() error {
+	err := f.RemoveAllAttachments()
+	if err != nil {
+		return nil
+	}
 
-	_, err := f.svc.DeletePolicy(&iot.DeletePolicyInput{
+	err = f.RemoveAllNonDefaultPolicyVersions()
+	if err != nil {
+		return nil
+	}
+
+	_, err = f.svc.DeletePolicy(&iot.DeletePolicyInput{
 		PolicyName: f.name,
 	})
 
 	return err
 }
 
+func (f *IoTPolicy) RemoveAllAttachments() error {
+	targets, err := f.ListAllPolicyTargets()
+	if err != nil {
+		return err
+	}
+	for _, target := range targets {
+		_, err = f.svc.DetachPolicy(&iot.DetachPolicyInput{
+			PolicyName: f.name,
+			Target:     target,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f *IoTPolicy) ListAllPolicyTargets() ([]*string, error) {
+	var targets []*string
+	params := &iot.ListTargetsForPolicyInput{
+		PolicyName: f.name,
+		PageSize:   aws.Int64(25),
+	}
+	for {
+		output, err := f.svc.ListTargetsForPolicy(params)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, output.Targets...)
+
+		if output.NextMarker == nil {
+			break
+		}
+
+		params.Marker = output.NextMarker
+	}
+	return targets, nil
+}
+
+func (f *IoTPolicy) RemoveAllNonDefaultPolicyVersions() error {
+	versions, err := f.ListAllPolicyVersions()
+	if err != nil {
+		return err
+	}
+
+	for _, policyVersion := range versions {
+		if aws.BoolValue(policyVersion.IsDefaultVersion) {
+			continue
+		}
+		_, err = f.svc.DeletePolicyVersion(&iot.DeletePolicyVersionInput{
+			PolicyName:      f.name,
+			PolicyVersionId: policyVersion.VersionId,
+		})
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (f *IoTPolicy) ListAllPolicyVersions() ([]*iot.PolicyVersion, error) {
+	output, err := f.svc.ListPolicyVersions(&iot.ListPolicyVersionsInput{
+		PolicyName: f.name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.PolicyVersions, nil
+
+}
 func (f *IoTPolicy) String() string {
 	return *f.name
 }

--- a/resources/iot-things-principal-attachments.go
+++ b/resources/iot-things-principal-attachments.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iot"
+)
+
+type IoTThingPrincipalAttachment struct {
+	svc       *iot.IoT
+	principal *string
+	thingName *string
+}
+
+func init() {
+	register("IoTThingPrincipalAttachment", ListIoTThingPrincipalAttachments)
+}
+
+func ListIoTThingPrincipalAttachments(sess *session.Session) ([]Resource, error) {
+	svc := iot.New(sess)
+	resources := []Resource{}
+
+	results, err := ListIoTThings(sess)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range results {
+		iotThing := resource.(*IoTThing)
+		output, err := svc.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+			ThingName: iotThing.name,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, principal := range output.Principals {
+			resources = append(resources, &IoTThingPrincipalAttachment{
+				svc:       svc,
+				principal: principal,
+				thingName: iotThing.name,
+			})
+		}
+
+	}
+
+	return resources, nil
+}
+
+func (f *IoTThingPrincipalAttachment) Remove() error {
+	_, err := f.svc.DetachThingPrincipal(&iot.DetachThingPrincipalInput{
+		Principal: f.principal,
+		ThingName: f.thingName,
+	})
+
+	return err
+}
+
+func (f *IoTThingPrincipalAttachment) String() string {
+	return fmt.Sprintf("%s -> %s", *f.thingName, *f.principal)
+}

--- a/resources/iot-things.go
+++ b/resources/iot-things.go
@@ -46,31 +46,8 @@ func ListIoTThings(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func (f *IoTThing) DetachAllPrincipals() error {
-	output, err := f.svc.ListThingPrincipals(&iot.ListThingPrincipalsInput{
-		ThingName: f.name,
-	})
-	if err != nil {
-		return err
-	}
-	for _, principal := range output.Principals {
-		_, err := f.svc.DetachThingPrincipal(&iot.DetachThingPrincipalInput{
-			Principal: principal,
-			ThingName: f.name,
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return err
-}
-
 func (f *IoTThing) Remove() error {
-	err := f.DetachAllPrincipals()
-	if err != nil {
-		return err
-	}
-	_, err = f.svc.DeleteThing(&iot.DeleteThingInput{
+	_, err := f.svc.DeleteThing(&iot.DeleteThingInput{
 		ThingName:       f.name,
 		ExpectedVersion: f.version,
 	})

--- a/resources/iot-things.go
+++ b/resources/iot-things.go
@@ -46,9 +46,31 @@ func ListIoTThings(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func (f *IoTThing) Remove() error {
+func (f *IoTThing) DetachAllPrincipals() error {
+	output, err := f.svc.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+		ThingName: f.name,
+	})
+	if err != nil {
+		return err
+	}
+	for _, principal := range output.Principals {
+		_, err := f.svc.DetachThingPrincipal(&iot.DetachThingPrincipalInput{
+			Principal: principal,
+			ThingName: f.name,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
 
-	_, err := f.svc.DeleteThing(&iot.DeleteThingInput{
+func (f *IoTThing) Remove() error {
+	err := f.DetachAllPrincipals()
+	if err != nil {
+		return err
+	}
+	_, err = f.svc.DeleteThing(&iot.DeleteThingInput{
 		ThingName:       f.name,
 		ExpectedVersion: f.version,
 	})

--- a/resources/route53-resource-records.go
+++ b/resources/route53-resource-records.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Route53ResourceRecordSet struct {
-	svc          *route53.Route53
-	hostedZoneId *string
-	data         *route53.ResourceRecordSet
-	changeId     *string
+	svc            *route53.Route53
+	hostedZoneName *string
+	hostedZoneId   *string
+	data           *route53.ResourceRecordSet
+	changeId       *string
 }
 
 func init() {
@@ -32,7 +33,7 @@ func ListRoute53ResourceRecordSets(sess *session.Session) ([]Resource, error) {
 
 	for _, resource := range sub {
 		zone := resource.(*Route53HostedZone)
-		rrs, err := ListResourceRecordsForZone(svc, zone.id)
+		rrs, err := ListResourceRecordsForZone(svc, zone.id, zone.name)
 		if err != nil {
 			return nil, err
 		}
@@ -43,7 +44,7 @@ func ListRoute53ResourceRecordSets(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func ListResourceRecordsForZone(svc *route53.Route53, zoneId *string) ([]Resource, error) {
+func ListResourceRecordsForZone(svc *route53.Route53, zoneId *string, zoneName *string) ([]Resource, error) {
 	params := &route53.ListResourceRecordSetsInput{
 		HostedZoneId: zoneId,
 	}
@@ -55,16 +56,17 @@ func ListResourceRecordsForZone(svc *route53.Route53, zoneId *string) ([]Resourc
 	resources := make([]Resource, 0)
 	for _, rrs := range resp.ResourceRecordSets {
 		resources = append(resources, &Route53ResourceRecordSet{
-			svc:          svc,
-			hostedZoneId: zoneId,
-			data:         rrs,
+			svc:            svc,
+			hostedZoneId:   zoneId,
+			hostedZoneName: zoneName,
+			data:           rrs,
 		})
 	}
 	return resources, nil
 }
 
 func (r *Route53ResourceRecordSet) Filter() error {
-	if *r.data.Type == "NS" {
+	if *r.data.Type == "NS" && *r.data.Name == *r.hostedZoneName {
 		return fmt.Errorf("cannot delete NS record")
 	}
 

--- a/resources/ssm-patchbaseline-association.go
+++ b/resources/ssm-patchbaseline-association.go
@@ -1,0 +1,82 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+type SSMPatchBaselineAssociation struct {
+	svc           *ssm.SSM
+	patchBaseline *string
+	patchGroup    *string
+}
+
+func init() {
+	register("SSMPatchBaselineAssociation", ListSSMPatchBaselineAssociations)
+}
+
+func ListSSMPatchGroups(svc *ssm.SSM) ([]*string, error) {
+	patchGroups := make([]*string, 0)
+	params := &ssm.DescribePatchGroupsInput{
+		MaxResults: aws.Int64(50),
+	}
+	for {
+		resp, err := svc.DescribePatchGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, mapping := range resp.Mappings {
+			patchGroups = append(patchGroups, mapping.PatchGroup)
+		}
+		if params.NextToken == nil {
+			break
+		}
+		params.NextToken = resp.NextToken
+	}
+	return patchGroups, nil
+}
+
+func ListSSMPatchBaselineAssociations(sess *session.Session) ([]Resource, error) {
+	svc := ssm.New(sess)
+
+	resources := make([]Resource, 0)
+
+	patchGroups, err := ListSSMPatchGroups(svc)
+	if err != nil {
+		return nil, err
+	}
+	for _, patchGroup := range patchGroups {
+		resp, err := svc.GetPatchBaselineForPatchGroup(&ssm.GetPatchBaselineForPatchGroupInput{
+			PatchGroup: patchGroup,
+		})
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, &SSMPatchBaselineAssociation{
+			svc:           svc,
+			patchBaseline: resp.BaselineId,
+			patchGroup:    patchGroup,
+		})
+	}
+
+	return resources, nil
+}
+
+func (e *SSMPatchBaselineAssociation) Remove() error {
+	_, err := e.svc.DeregisterPatchBaselineForPatchGroup(&ssm.DeregisterPatchBaselineForPatchGroupInput{
+		BaselineId: e.patchBaseline,
+		PatchGroup: e.patchGroup,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *SSMPatchBaselineAssociation) String() string {
+	return fmt.Sprintf("%s -> %s", *e.patchBaseline, *e.patchGroup)
+}


### PR DESCRIPTION
- Removes all targets attached to IoTPolicy ( refactored from the comments in  IoT associations and fixes (https://github.com/rebuy-de/aws-nuke/pull/284)
- Removes all non default versions - this is required, otherwise we get an error:
"DeleteConflictException: The policy cannot be deleted as versions other than than default version exist"