### PR TITLE
add --force-sleep param instead of statically setting the wait to 15 seconds

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -33,6 +33,9 @@ func NewNuke(params NukeParameters, account awsutil.Account) *Nuke {
 func (n *Nuke) Run() error {
 	var err error
 
+	if n.Parameters.ForceSleep < 3 {
+		return fmt.Errorf("Value for --force-sleep cannot be less than 3 seconds. This is for your own protection.")
+	}
 	forceSleep := time.Duration(n.Parameters.ForceSleep) * time.Second
 
 	fmt.Printf("aws-nuke version %s - %s - %s\n\n", BuildVersion, BuildDate, BuildHash)

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -17,8 +17,6 @@ type Nuke struct {
 
 	ResourceTypes types.Collection
 
-	ForceSleep time.Duration
-
 	items Queue
 }
 
@@ -26,7 +24,6 @@ func NewNuke(params NukeParameters, account awsutil.Account) *Nuke {
 	n := Nuke{
 		Parameters: params,
 		Account:    account,
-		ForceSleep: 15 * time.Second,
 	}
 
 	return &n
@@ -34,6 +31,8 @@ func NewNuke(params NukeParameters, account awsutil.Account) *Nuke {
 
 func (n *Nuke) Run() error {
 	var err error
+
+	forceSleep := time.Duration(n.Parameters.ForceSleep) * time.Second
 
 	fmt.Printf("aws-nuke version %s - %s - %s\n\n", BuildVersion, BuildDate, BuildHash)
 
@@ -45,8 +44,8 @@ func (n *Nuke) Run() error {
 	fmt.Printf("Do you really want to nuke the account with "+
 		"the ID %s and the alias '%s'?\n", n.Account.ID(), n.Account.Alias())
 	if n.Parameters.Force {
-		fmt.Printf("Waiting %v before continuing.\n", n.ForceSleep)
-		time.Sleep(n.ForceSleep)
+		fmt.Printf("Waiting %v before continuing.\n", forceSleep)
+		time.Sleep(forceSleep)
 	} else {
 		fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
 		err = Prompt(n.Account.Alias())
@@ -73,8 +72,8 @@ func (n *Nuke) Run() error {
 	fmt.Printf("Do you really want to nuke these resources on the account with "+
 		"the ID %s and the alias '%s'?\n", n.Account.ID(), n.Account.Alias())
 	if n.Parameters.Force {
-		fmt.Printf("Waiting %v before continuing.\n", n.ForceSleep)
-		time.Sleep(n.ForceSleep)
+		fmt.Printf("Waiting %v before continuing.\n", forceSleep)
+		time.Sleep(forceSleep)
 	} else {
 		fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
 		err = Prompt(n.Account.Alias())

--- a/cmd/params.go
+++ b/cmd/params.go
@@ -11,8 +11,9 @@ type NukeParameters struct {
 	Targets  []string
 	Excludes []string
 
-	NoDryRun bool
-	Force    bool
+	NoDryRun   bool
+	Force      bool
+	ForceSleep int
 
 	MaxWaitRetries int
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,11 @@ func NewRootCommand() *cobra.Command {
 	command.PersistentFlags().BoolVar(
 		&params.Force, "force", false,
 		"Don't ask for confirmation before deleting resources. "+
-			"Instead it waits 15s before continuing.")
+			"Instead it waits 15s before continuing. Set --force-sleep to change the wait time.")
+	command.PersistentFlags().IntVar(
+		&params.ForceSleep, "force-sleep", 15,
+		"If specified and --force is set, wait this many seconds before deleting resources. "+
+			"Defaults to 15.")
 	command.PersistentFlags().IntVar(
 		&params.MaxWaitRetries, "max-wait-retries", 0,
 		"If specified, the program will exit if resources are stuck in waiting for this many iterations. "+

--- a/main.go
+++ b/main.go
@@ -13,8 +13,9 @@ type NukeParameters struct {
 	AccessKeyID     string
 	SecretAccessKey string
 
-	NoDryRun bool
-	Force    bool
+	NoDryRun   bool
+	Force      bool
+	ForceSleep int
 
 	MaxWaitRetries int
 }


### PR DESCRIPTION
this is most useful if run as part of a lambda, where sleeps == $$.