### PR TITLE
add support for Transit gateways and its vpc attachments

### DIFF
--- a/resources/ec2-tgw-attachments.go
+++ b/resources/ec2-tgw-attachments.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type EC2TGWAttachment struct {
+	svc  *ec2.EC2
+	tgwa *ec2.TransitGatewayAttachment
+}
+
+func init() {
+	register("EC2TGWAttachment", ListEC2TGWAttachments)
+}
+
+func ListEC2TGWAttachments(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	params := &ec2.DescribeTransitGatewayAttachmentsInput{}
+	resources := make([]Resource, 0)
+	for {
+		resp, err := svc.DescribeTransitGatewayAttachments(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tgwa := range resp.TransitGatewayAttachments {
+			resources = append(resources, &EC2TGWAttachment{
+				svc:  svc,
+				tgwa: tgwa,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params = &ec2.DescribeTransitGatewayAttachmentsInput{
+			NextToken: resp.NextToken,
+		}
+	}
+
+	return resources, nil
+}
+
+func (e *EC2TGWAttachment) Remove() error {
+	if *e.tgwa.ResourceType == "VPN" {
+		// This will get deleted as part of EC2VPNConnection, there is no API
+		// as part of TGW to delete VPN attachments.
+		return fmt.Errorf("VPN attachment")
+	}
+	params := &ec2.DeleteTransitGatewayVpcAttachmentInput{
+		TransitGatewayAttachmentId: e.tgwa.TransitGatewayAttachmentId,
+	}
+
+	_, err := e.svc.DeleteTransitGatewayVpcAttachment(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *EC2TGWAttachment) Filter() error {
+	if *e.tgwa.State == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (e *EC2TGWAttachment) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tgwa.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("ID", e.tgwa.TransitGatewayAttachmentId)
+	return properties
+}
+
+func (e *EC2TGWAttachment) String() string {
+	return fmt.Sprintf("%s(%s)", *e.tgwa.TransitGatewayAttachmentId, *e.tgwa.ResourceType)
+}

--- a/resources/ec2-tgw.go
+++ b/resources/ec2-tgw.go
@@ -1,0 +1,81 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type EC2TGW struct {
+	svc *ec2.EC2
+	tgw *ec2.TransitGateway
+}
+
+func init() {
+	register("EC2TGW", ListEC2TGWs)
+}
+
+func ListEC2TGWs(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	params := &ec2.DescribeTransitGatewaysInput{}
+	resources := make([]Resource, 0)
+	for {
+		resp, err := svc.DescribeTransitGateways(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tgw := range resp.TransitGateways {
+			resources = append(resources, &EC2TGW{
+				svc: svc,
+				tgw: tgw,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params = &ec2.DescribeTransitGatewaysInput{
+			NextToken: resp.NextToken,
+		}
+	}
+
+	return resources, nil
+}
+
+func (e *EC2TGW) Remove() error {
+	params := &ec2.DeleteTransitGatewayInput{
+		TransitGatewayId: e.tgw.TransitGatewayId,
+	}
+
+	_, err := e.svc.DeleteTransitGateway(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *EC2TGW) Filter() error {
+	if *e.tgw.State == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (e *EC2TGW) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tgw.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("ID", e.tgw.TransitGatewayId)
+	return properties
+}
+
+func (e *EC2TGW) String() string {
+	return *e.tgw.TransitGatewayId
+}


### PR DESCRIPTION
Support for transit gateways and vpc attachments.
VPN attachments to transit gateways are deleted as part of VPN Connections