### PR TITLE
Add AWS Backup resources 

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -41,3 +41,7 @@ accounts:
       CloudFormationStack:
       - property: "tag:team"
         value: "myTeam"
+      EC2Snapshot:
+      - property: "tag:team"
+        type: regex
+        value: ".+"

--- a/resources/backup-plans.go
+++ b/resources/backup-plans.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type BackupPlan struct {
+	svc  *backup.Backup
+	id   string
+	name string
+	arn  string
+	tags map[string]*string
+}
+
+func init() {
+	register("AWSBackupPlan", ListBackupPlans)
+}
+
+func ListBackupPlans(sess *session.Session) ([]Resource, error) {
+	svc := backup.New(sess)
+	false_value := false
+	max_backups_len := int64(100)
+	params := &backup.ListBackupPlansInput{
+		IncludeDeleted: &false_value,
+		MaxResults:     &max_backups_len, // aws default limit on number of backup plans per account
+	}
+	resp, err := svc.ListBackupPlans(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.BackupPlansList {
+		tagsOutput, _ := svc.ListTags(&backup.ListTagsInput{ResourceArn: out.BackupPlanArn})
+		resources = append(resources, &BackupPlan{
+			svc:  svc,
+			id:   *out.BackupPlanId,
+			name: *out.BackupPlanName,
+			arn:  *out.BackupPlanArn,
+			tags: tagsOutput.Tags,
+		})
+	}
+
+	return resources, nil
+}
+
+func (b *BackupPlan) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", b.id)
+	properties.Set("Name", b.name)
+	for tagKey, tagValue := range b.tags {
+		properties.Set(fmt.Sprintf("tag:%v", tagKey), *tagValue)
+	}
+	return properties
+}
+
+func (b *BackupPlan) Remove() error {
+	_, err := b.svc.DeleteBackupPlan(&backup.DeleteBackupPlanInput{
+		BackupPlanId: &b.id,
+	})
+	return err
+}
+
+func (b *BackupPlan) String() string {
+	return b.arn
+}

--- a/resources/backup-recovery-points.go
+++ b/resources/backup-recovery-points.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type BackupRecoveryPoint struct {
+	svc             *backup.Backup
+	arn             string
+	backupVaultName string
+}
+
+func init() {
+	register("AWSBackupRecoveryPoint", ListBackupRecoveryPoints)
+}
+
+func ListBackupRecoveryPoints(sess *session.Session) ([]Resource, error) {
+	svc := backup.New(sess)
+	max_vaults_len := int64(100)
+	params := &backup.ListBackupVaultsInput{
+		MaxResults: &max_vaults_len, // aws default limit on number of backup vaults per account
+	}
+	resp, err := svc.ListBackupVaults(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.BackupVaultList {
+		recoveryPointsOutput, _ := svc.ListRecoveryPointsByBackupVault(&backup.ListRecoveryPointsByBackupVaultInput{BackupVaultName: out.BackupVaultName})
+		for _, rp := range recoveryPointsOutput.RecoveryPoints {
+			resources = append(resources, &BackupRecoveryPoint{
+				svc:             svc,
+				arn:             *rp.RecoveryPointArn,
+				backupVaultName: *out.BackupVaultName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (b *BackupRecoveryPoint) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("BackupVault", b.backupVaultName)
+	return properties
+}
+
+func (b *BackupRecoveryPoint) Remove() error {
+	_, err := b.svc.DeleteRecoveryPoint(&backup.DeleteRecoveryPointInput{
+		BackupVaultName:  &b.backupVaultName,
+		RecoveryPointArn: &b.arn,
+	})
+	return err
+}
+
+func (b *BackupRecoveryPoint) String() string {
+	return fmt.Sprintf("%s", b.arn)
+}

--- a/resources/backup-selections.go
+++ b/resources/backup-selections.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type BackupSelection struct {
+	svc           *backup.Backup
+	planId        string
+	selectionId   string
+	selectionName string
+}
+
+func init() {
+	register("AWSBackupSelection", ListBackupSelections)
+}
+
+func ListBackupSelections(sess *session.Session) ([]Resource, error) {
+	svc := backup.New(sess)
+	false_value := false
+	max_backups_len := int64(100)
+	params := &backup.ListBackupPlansInput{
+		IncludeDeleted: &false_value,
+		MaxResults:     &max_backups_len, // aws default limit on number of backup plans per account
+	}
+	resp, err := svc.ListBackupPlans(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.BackupPlansList {
+		selectionsOutput, _ := svc.ListBackupSelections(&backup.ListBackupSelectionsInput{BackupPlanId: out.BackupPlanId})
+		for _, selection := range selectionsOutput.BackupSelectionsList {
+			resources = append(resources, &BackupSelection{
+				svc:           svc,
+				planId:        *selection.BackupPlanId,
+				selectionId:   *selection.SelectionId,
+				selectionName: *selection.SelectionName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (b *BackupSelection) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", b.selectionName)
+	properties.Set("ID", b.selectionId)
+	properties.Set("PlanID", b.planId)
+	return properties
+}
+
+func (b *BackupSelection) Remove() error {
+	_, err := b.svc.DeleteBackupSelection(&backup.DeleteBackupSelectionInput{
+		BackupPlanId: &b.planId,
+		SelectionId:  &b.selectionId,
+	})
+	return err
+}
+
+func (b *BackupSelection) String() string {
+	return fmt.Sprintf("%s (%s)", b.planId, b.selectionId)
+}

--- a/resources/backup-vaults.go
+++ b/resources/backup-vaults.go
@@ -1,0 +1,64 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type BackupVault struct {
+	svc  *backup.Backup
+	arn  string
+	name string
+	tags map[string]*string
+}
+
+func init() {
+	register("AWSBackupVault", ListBackupVaults)
+}
+
+func ListBackupVaults(sess *session.Session) ([]Resource, error) {
+	svc := backup.New(sess)
+	max_vaults_len := int64(100)
+	params := &backup.ListBackupVaultsInput{
+		MaxResults: &max_vaults_len, // aws default limit on number of backup vaults per account
+	}
+	resp, err := svc.ListBackupVaults(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, out := range resp.BackupVaultList {
+		tagsOutput, _ := svc.ListTags(&backup.ListTagsInput{ResourceArn: out.BackupVaultArn})
+		resources = append(resources, &BackupVault{
+			svc:  svc,
+			name: *out.BackupVaultName,
+			arn:  *out.BackupVaultArn,
+			tags: tagsOutput.Tags,
+		})
+	}
+
+	return resources, nil
+}
+
+func (b *BackupVault) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", b.name)
+	for tagKey, tagValue := range b.tags {
+		properties.Set(fmt.Sprintf("tag:%v", tagKey), *tagValue)
+	}
+	return properties
+}
+
+func (b *BackupVault) Remove() error {
+	_, err := b.svc.DeleteBackupVault(&backup.DeleteBackupVaultInput{
+		BackupVaultName: &b.name,
+	})
+	return err
+}
+
+func (b *BackupVault) String() string {
+	return b.arn
+}


### PR DESCRIPTION
# Changes
* Added these AWS Backup resources:
  * Backup plans
  * Backup vaults
  * Backup selections
  * Recovery points


* Added ability to filter EC2 snapshots by tags - AWS snapshots are reserved and cannot be nuked through EC2 so a user can exclude AWS reserved-snapshots by filtering on something like this:

```yaml
presets:
  non_aws_backup_snapshots:
    filters:
      EC2Snapshot:
        - property: "tag:aws:backup:source-resource"
          type: regex
          value: ".+"
```

# Example
```yaml
regions:
  - global
  - us-east-1

account-blacklist:
  - "999999999999" # placebo production account

accounts:
  238403284032840:
    presets:
      - "non_aws_backup_snapshots"

resource-types:
  targets:
    - EC2Snapshot
    - AWSBackupPlan
    - AWSBackupVault
    - AWSBackupSelection
    - AWSBackupRecoveryPoint

presets:
  non_aws_backup_snapshots:
    filters:
      EC2Snapshot:
        - property: "tag:aws:backup:source-resource"
          type: regex
          value: ".+"
```