### PR TITLE
Enable Tag filter on EC2 Images

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -45,3 +45,6 @@ accounts:
       - property: "tag:team"
         type: regex
         value: ".+"
+      EC2Image:
+      - property: "tag:release"
+        value: "production"

--- a/resources/ec2-images.go
+++ b/resources/ec2-images.go
@@ -10,7 +10,7 @@ import (
 type EC2Image struct {
 	svc  *ec2.EC2
 	id   string
-	tags []*ec2.Tags
+	tags []*ec2.Tag
 }
 
 func init() {
@@ -34,7 +34,7 @@ func ListEC2Images(sess *session.Session) ([]Resource, error) {
 		resources = append(resources, &EC2Image{
 			svc:  svc,
 			id:   *out.ImageId,
-			tags: *out.Tags,
+			tags: out.Tags,
 		})
 	}
 

--- a/resources/ec2-images.go
+++ b/resources/ec2-images.go
@@ -4,11 +4,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2Image struct {
-	svc *ec2.EC2
-	id  string
+	svc  *ec2.EC2
+	id   string
+	tags []*ec2.Tags
 }
 
 func init() {
@@ -30,8 +32,9 @@ func ListEC2Images(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, out := range resp.Images {
 		resources = append(resources, &EC2Image{
-			svc: svc,
-			id:  *out.ImageId,
+			svc:  svc,
+			id:   *out.ImageId,
+			tags: *out.Tags,
 		})
 	}
 
@@ -43,6 +46,14 @@ func (e *EC2Image) Remove() error {
 		ImageId: &e.id,
 	})
 	return err
+}
+
+func (e *EC2Image) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (e *EC2Image) String() string {


### PR DESCRIPTION
Found that I was unable to filter certain AMIs via tags. This allows us to filter certain AMIs via tags

```
us-west-2 - EC2Image - ami-1234567df81e826c58 - [tag:release: "production", tag:database: "cassandra"] - filtered by config
us-west-2 - EC2Image - ami-1234553054dc19d83 - [tag:operating_system: "ubuntu"] - would remove
```

```
# optional: restrict nuking to these resources
resource-types:
  targets:
  - EC2Image

accounts:
  123456789:
    filters:
      EC2Image:
      - property: "tag:release"
        value: "production"
```