### PR TITLE
Register MSK service

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -17,6 +17,7 @@ resource-types:
   - Route53HostedZone
   - EC2Instance
   - CloudFormationStack
+  - MSKCluster
 
 accounts:
   555133742:

--- a/resources/msk-cluster.go
+++ b/resources/msk-cluster.go
@@ -1,0 +1,61 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type MSKCluster struct {
+	svc  *kafka.Kafka
+	arn  string
+	name string
+}
+
+func init() {
+	register("MSKCluster", ListMSKCluster)
+}
+
+func ListMSKCluster(sess *session.Session) ([]Resource, error) {
+	svc := kafka.New(sess)
+	params := &kafka.ListClustersInput{}
+	resp, err := svc.ListClusters(params)
+
+	if err != nil {
+		return nil, err
+	}
+	resources := make([]Resource, 0)
+	for _, cluster := range resp.ClusterInfoList {
+		resources = append(resources, &MSKCluster{
+			svc:  svc,
+			arn:  *cluster.ClusterArn,
+			name: *cluster.ClusterName,
+		})
+
+	}
+	return resources, nil
+}
+
+func (m *MSKCluster) Remove() error {
+	params := &kafka.DeleteClusterInput{
+		ClusterArn: &m.arn,
+	}
+
+	_, err := m.svc.DeleteCluster(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *MSKCluster) String() string {
+	return m.arn
+}
+
+func (m *MSKCluster) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ARN", m.arn)
+	properties.Set("Name", m.name)
+
+	return properties
+}


### PR DESCRIPTION
An attempt to register MSK Service requested in issue #354 

```
rabbbithole$ docker run -a stdin -a stdout -ti rebuy-de/aws_nuke -c config/example.yaml --secret-access-key=$AWS_SECRET_ACCESS_KEY --access-key-id=$AWS_ACCESS_KEY_ID
aws-nuke version v2.10.0.4.g6b3bdb7.dirty - Sat Apr 27 07:01:51 UTC 2019 - 6b3bdb7c2bc4dfb65b08ec404983539b059fe243

Do you really want to nuke the account with the ID 12344123445 and the alias 'test-account'?
Do you want to continue? Enter account alias to continue.
> test-account

us-east-2 - MSKCluster - arn:aws:kafka:us-east-2:12344123445:cluster/test-cluster/4a914bb3-cadd-4e2c-b9d8-ad8166d381ff-3 - [Arn: "arn:aws:kafka:us-east-2:12344123445:cluster/test-cluster/4a914bb3-cadd-4e2c-b9d8-ad8166d381ff-3", Name: "test-cluster"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

The above resources would be deleted with the supplied configuration. Provide --no-dry-run to actually destroy resources.
```