### PR TITLE
Enable tags for EC2 DHCP Options

### DIFF
--- a/resources/ec2-dhcp-options.go
+++ b/resources/ec2-dhcp-options.go
@@ -3,11 +3,13 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2DHCPOption struct {
-	svc *ec2.EC2
-	id  *string
+	svc  *ec2.EC2
+	id   *string
+	tags []*ec2.Tag
 }
 
 func init() {
@@ -26,8 +28,9 @@ func ListEC2DHCPOptions(sess *session.Session) ([]Resource, error) {
 	for _, out := range resp.DhcpOptions {
 
 		resources = append(resources, &EC2DHCPOption{
-			svc: svc,
-			id:  out.DhcpOptionsId,
+			svc:  svc,
+			id:   out.DhcpOptionsId,
+			tags: out.Tags,
 		})
 	}
 
@@ -45,6 +48,14 @@ func (e *EC2DHCPOption) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *EC2DHCPOption) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
 }
 
 func (e *EC2DHCPOption) String() string {


### PR DESCRIPTION
Many thanks for a very useful project.

I ported https://github.com/rebuy-de/aws-nuke/commit/4dfad10643e291fa3353b82fe23ffe614f0b91f0 for EC2 DHCP Options.

I am actually using this patch.