### PR TITLE
Add tag filter for S3 Bucket, RDS Resources, DynamoDB Tables, Lambda Functions

### DIFF
--- a/resources/dynamodb-tables.go
+++ b/resources/dynamodb-tables.go
@@ -4,11 +4,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type DynamoDBTable struct {
-	svc *dynamodb.DynamoDB
-	id  string
+	svc  *dynamodb.DynamoDB
+	id   string
+	tags []*dynamodb.Tag
 }
 
 func init() {
@@ -25,9 +27,16 @@ func ListDynamoDBTables(sess *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, tableName := range resp.TableNames {
+		tags, err := GetTableTags(svc, tableName)
+
+		if err != nil {
+			continue
+		}
+
 		resources = append(resources, &DynamoDBTable{
 			svc: svc,
 			id:  *tableName,
+			tags: tags,
 		})
 	}
 
@@ -46,6 +55,38 @@ func (i *DynamoDBTable) Remove() error {
 
 	return nil
 }
+
+func GetTableTags(svc *dynamodb.DynamoDB, tableName *string) ([]*dynamodb.Tag, error) {
+	result, err := svc.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: aws.String(*tableName),
+	})
+
+	if err != nil {
+		return make([]*dynamodb.Tag, 0), err
+	}
+
+	tags, err :=  svc.ListTagsOfResource(&dynamodb.ListTagsOfResourceInput{
+		ResourceArn: result.Table.TableArn,
+	})
+
+	if err != nil {
+		return make([]*dynamodb.Tag, 0), err
+	}
+
+	return tags.Tags, nil
+}
+
+func (i *DynamoDBTable) Properties() types.Properties {
+        properties := types.NewProperties()
+        properties.Set("Identifier", i.id)
+
+        for _, tag := range i.tags {
+                properties.SetTag(tag.Key, tag.Value)
+        }
+
+        return properties
+}
+
 
 func (i *DynamoDBTable) String() string {
 	return i.id

--- a/resources/lambda-functions.go
+++ b/resources/lambda-functions.go
@@ -1,13 +1,16 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type LambdaFunction struct {
 	svc          *lambda.Lambda
 	functionName *string
+	tags         *map[string]*string
 }
 
 func init() {
@@ -25,13 +28,44 @@ func ListLambdaFunctions(sess *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, function := range resp.Functions {
+		tags, err := retrieveLambdaTags(svc, *function.FunctionArn)
+		if err != nil {
+			continue
+		}
+
 		resources = append(resources, &LambdaFunction{
 			svc:          svc,
 			functionName: function.FunctionName,
+			tags: &tags,
 		})
 	}
 
 	return resources, nil
+}
+
+func retrieveLambdaTags(svc *lambda.Lambda, arn string) (map[string]*string, error) {
+	input := &lambda.ListTagsInput {
+		Resource: aws.String(arn),
+	}
+
+	result, err := svc.ListTags(input)
+
+	if err != nil {
+		return make(map[string]*string, 0), err
+	}
+
+	return result.Tags, nil
+}
+
+func (f *LambdaFunction) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", f.functionName)
+
+	for key, val := range *f.tags {
+		properties.SetTag(&key, val)
+	}
+
+	return properties
 }
 
 func (f *LambdaFunction) Remove() error {

--- a/resources/lambda-functions.go
+++ b/resources/lambda-functions.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
@@ -10,7 +9,7 @@ import (
 type LambdaFunction struct {
 	svc          *lambda.Lambda
 	functionName *string
-	tags         *map[string]*string
+	tags         map[string]*string
 }
 
 func init() {
@@ -28,7 +27,10 @@ func ListLambdaFunctions(sess *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, function := range resp.Functions {
-		tags, err := retrieveLambdaTags(svc, *function.FunctionArn)
+		tags, err := svc.ListTags(&lambda.ListTagsInput{
+			Resource: function.FunctionArn,
+		})
+
 		if err != nil {
 			continue
 		}
@@ -36,32 +38,18 @@ func ListLambdaFunctions(sess *session.Session) ([]Resource, error) {
 		resources = append(resources, &LambdaFunction{
 			svc:          svc,
 			functionName: function.FunctionName,
-			tags: &tags,
+			tags:         tags.Tags,
 		})
 	}
 
 	return resources, nil
 }
 
-func retrieveLambdaTags(svc *lambda.Lambda, arn string) (map[string]*string, error) {
-	input := &lambda.ListTagsInput {
-		Resource: aws.String(arn),
-	}
-
-	result, err := svc.ListTags(input)
-
-	if err != nil {
-		return make(map[string]*string, 0), err
-	}
-
-	return result.Tags, nil
-}
-
 func (f *LambdaFunction) Properties() types.Properties {
 	properties := types.NewProperties()
 	properties.Set("Name", f.functionName)
 
-	for key, val := range *f.tags {
+	for key, val := range f.tags {
 		properties.SetTag(&key, val)
 	}
 

--- a/resources/rds-dbparametergroups.go
+++ b/resources/rds-dbparametergroups.go
@@ -7,11 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type RDSDBParameterGroup struct {
 	svc  *rds.RDS
 	name *string
+	tags []*rds.Tag
 }
 
 func init() {
@@ -28,9 +30,18 @@ func ListRDSParameterGroups(sess *session.Session) ([]Resource, error) {
 	}
 	var resources []Resource
 	for _, parametergroup := range resp.DBParameterGroups {
+		tags, err := svc.ListTagsForResource(&rds.ListTagsForResourceInput{
+			ResourceName: parametergroup.DBParameterGroupArn,
+		})
+
+		if err != nil {
+			continue
+		}
+
 		resources = append(resources, &RDSDBParameterGroup{
 			svc:  svc,
 			name: parametergroup.DBParameterGroupName,
+			tags: tags.TagList,
 		})
 
 	}
@@ -60,4 +71,15 @@ func (i *RDSDBParameterGroup) Remove() error {
 
 func (i *RDSDBParameterGroup) String() string {
 	return *i.name
+}
+
+func (i *RDSDBParameterGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", i.name)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
 }

--- a/resources/rds-subnets.go
+++ b/resources/rds-subnets.go
@@ -4,11 +4,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type RDSDBSubnetGroup struct {
 	svc  *rds.RDS
 	name *string
+	tags []*rds.Tag
 }
 
 func init() {
@@ -25,9 +27,18 @@ func ListRDSSubnetGroups(sess *session.Session) ([]Resource, error) {
 	}
 	var resources []Resource
 	for _, subnetGroup := range resp.DBSubnetGroups {
+		tags, err := svc.ListTagsForResource(&rds.ListTagsForResourceInput{
+                        ResourceName: subnetGroup.DBSubnetGroupArn,
+                })
+
+                if err != nil {
+                        continue
+                }
+
 		resources = append(resources, &RDSDBSubnetGroup{
 			svc:  svc,
 			name: subnetGroup.DBSubnetGroupName,
+			tags: tags.TagList,
 		})
 
 	}
@@ -50,4 +61,15 @@ func (i *RDSDBSubnetGroup) Remove() error {
 
 func (i *RDSDBSubnetGroup) String() string {
 	return *i.name
+}
+
+func (i *RDSDBSubnetGroup) Properties() types.Properties {
+        properties := types.NewProperties()
+        properties.Set("Name", i.name)
+
+        for _, tag := range i.tags {
+                properties.SetTag(tag.Key, tag.Value)
+        }
+
+        return properties
 }

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -33,7 +33,7 @@ func ListS3Buckets(s *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, name := range buckets {
-		result, err := svc.GetBucketTagging(&s3.GetBucketTaggingInput{
+		tags, err := svc.GetBucketTagging(&s3.GetBucketTaggingInput{
 			Bucket: aws.String(name),
 		})
 
@@ -44,7 +44,7 @@ func ListS3Buckets(s *session.Session) ([]Resource, error) {
 		resources = append(resources, &S3Bucket{
 			svc:  svc,
 			name: name,
-			tags: result.TagSet,
+			tags: tags.TagSet,
 		})
 	}
 

--- a/resources/s3-objects.go
+++ b/resources/s3-objects.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/rebuy-de/aws-nuke/pkg/types"


### PR DESCRIPTION
Added tag properties to S3 bucket, RDS resources (snapshots already had tags), DynamoDB Tables, and lambda functions.

I originally tried adding tags for S3 Objects, but I realized the API Call across several buckets with thousands of objects could get VERY costly. Because of this, I took that out and decided not to add any additional properties to S3 Objects.