### PR TITLE
Format resource properties in sorted order

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/rebuy-de/aws-nuke/resources"
@@ -22,6 +24,23 @@ var (
 	ColorResourceProperties = *color.New(color.Italic)
 )
 
+
+// Format the resource properties in sorted order ready for printing.
+// This ensures that multiple runs of aws-nuke produce stable output so
+// that they can be compared with each other.
+func Sorted(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	sorted := make([]string, 0, len(m))
+	for k := range keys {
+		sorted = append(sorted, fmt.Sprintf("%s: \"%s\"", keys[k], m[keys[k]]))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(sorted, ", "))
+}
+
 func Log(region Region, resourceType string, r resources.Resource, c color.Color, msg string) {
 	ColorRegion.Printf("%s", region.Name)
 	fmt.Printf(" - ")
@@ -36,7 +55,7 @@ func Log(region Region, resourceType string, r resources.Resource, c color.Color
 
 	rProp, ok := r.(resources.ResourcePropertyGetter)
 	if ok {
-		ColorResourceProperties.Print(rProp.Properties())
+		ColorResourceProperties.Print(Sorted(rProp.Properties()))
 		fmt.Printf(" - ")
 	}
 


### PR DESCRIPTION
This ensures that multiple runs of aws-nuke produce stable output so
that they can be compared with each other.

This is likely terrible golang style/design.  Happy to take advice on how to make it more idiomatic.