### PR TITLE
feat: Add State as filter option for ec2 volumes

### DIFF
--- a/resources/ec2-volume.go
+++ b/resources/ec2-volume.go
@@ -43,6 +43,7 @@ func (e *EC2Volume) Remove() error {
 
 func (e *EC2Volume) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("State", e.volume.State)
 	for _, tagValue := range e.volume.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}


### PR DESCRIPTION
Added state as an additional filter option for ec2 volumes. I think this might be useful in the event that you want to only 'nuke' volumes currently going unused. 

Tested with volumes in various states with config:
```
EC2Volume:
         - property: 'State'
           value: 'in-use'
```