### PR TITLE
Fix: catch s3 bucket tag error properly

### DIFF
--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -38,7 +39,13 @@ func ListS3Buckets(s *session.Session) ([]Resource, error) {
 		})
 
 		if err != nil {
-			continue
+			if aerr, ok := err.(awserr.Error); ok {
+				if "NoSuchTagSet" != aerr.Code() {
+					continue
+				}
+			} else {
+				continue
+			}
 		}
 
 		resources = append(resources, &S3Bucket{

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -40,12 +40,15 @@ func ListS3Buckets(s *session.Session) ([]Resource, error) {
 
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
-				if "NoSuchTagSet" != aerr.Code() {
-					continue
+				if aerr.Code() == "NoSuchTagSet" {
+					resources = append(resources, &S3Bucket{
+						svc: svc,
+						name: name,
+						tags: make([]*s3.Tag, 0),
+					})
 				}
-			} else {
-				continue
 			}
+			continue
 		}
 
 		resources = append(resources, &S3Bucket{


### PR DESCRIPTION
Untagged buckets get returned an error from GetBucketTagging API call. So, buckets without tags currently do not get displayed. This fix now will only skip buckets on actual api call errors.

Sorry I didn't catch this when I pushed these changes earlier :/