### PR TITLE
Adds additional AWS IoT considerations for deletion

### DIFF
--- a/resources/iot-certificates.go
+++ b/resources/iot-certificates.go
@@ -7,9 +7,8 @@ import (
 )
 
 type IoTCertificate struct {
-	svc    *iot.IoT
-	ID     *string
-	status *string
+	svc *iot.IoT
+	ID  *string
 }
 
 func init() {
@@ -29,9 +28,8 @@ func ListIoTCertificates(sess *session.Session) ([]Resource, error) {
 
 	for _, certificate := range output.Certificates {
 		resources = append(resources, &IoTCertificate{
-			svc:    svc,
-			ID:     certificate.CertificateId,
-			status: certificate.Status,
+			svc: svc,
+			ID:  certificate.CertificateId,
 		})
 	}
 

--- a/resources/iot-certificates.go
+++ b/resources/iot-certificates.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iot"
 )
@@ -38,20 +39,16 @@ func ListIoTCertificates(sess *session.Session) ([]Resource, error) {
 }
 
 func (f *IoTCertificate) Remove() error {
-	// deactivate the certificate first if it is still active
-	desiredStatus := "INACTIVE"
-	if *f.status == "ACTIVE" {
-		_, err := f.svc.UpdateCertificate(&iot.UpdateCertificateInput{
-			CertificateId: f.ID,
-			NewStatus:     &desiredStatus,
-		})
 
-		if err != nil {
-			return err
-		}
+	_, err := f.svc.UpdateCertificate(&iot.UpdateCertificateInput{
+		CertificateId: f.ID,
+		NewStatus:     aws.String("INACTIVE"),
+	})
+	if err != nil {
+		return err
 	}
 
-	_, err := f.svc.DeleteCertificate(&iot.DeleteCertificateInput{
+	_, err = f.svc.DeleteCertificate(&iot.DeleteCertificateInput{
 		CertificateId: f.ID,
 	})
 

--- a/resources/iot-things.go
+++ b/resources/iot-things.go
@@ -17,7 +17,7 @@ func init() {
 	register("IoTThing", ListIoTThings)
 }
 
-func listIotThingPrincipals(f *IoTThing) (*IoTThing, error) {
+func listIoTThingPrincipals(f *IoTThing) (*IoTThing, error) {
 	params := &iot.ListThingPrincipalsInput{
 		ThingName: f.name,
 	}
@@ -46,7 +46,7 @@ func ListIoTThings(sess *session.Session) ([]Resource, error) {
 
 		// gather dependent principals
 		for _, thing := range output.Things {
-			t, err := listIotThingPrincipals(&IoTThing{
+			t, err := listIoTThingPrincipals(&IoTThing{
 				svc:     svc,
 				name:    thing.ThingName,
 				version: thing.Version,


### PR DESCRIPTION
This PR addresses the points detailed in #374. 

Changes:
- Now detaches attached principals to IoT things prior to deletion
- Now detaches attached targets to IoT policies prior to deletion
- Now deprecates non-default versions of IoT policies prior to deletion
- Now deactivates IoT certificates prior to deletion