### PR TITLE
Adding filters to group policy attachments

### DIFF
--- a/resources/iam-group-policy-attachments.go
+++ b/resources/iam-group-policy-attachments.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type IAMGroupPolicyAttachment struct {
@@ -60,6 +61,12 @@ func (e *IAMGroupPolicyAttachment) Remove() error {
 	}
 
 	return nil
+}
+
+func (e *IAMGroupPolicyAttachment) Properties() types.Properties {
+	return types.NewProperties().
+		Set("RoleName", e.roleName).
+		Set("PolicyName", e.policyName)
 }
 
 func (e *IAMGroupPolicyAttachment) String() string {


### PR DESCRIPTION
We wanted to filter by the group on the group policy attachments but it was difficult without exposing the properties. I have added the group policy attachment properties to be exposed the same way IAMRolePolicyAttachment is done.