### PR TITLE
introduce feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,21 @@ If an exclude is used, then all its resource types will not be deleted.
 aws-nuke resource-types
 ```
 
+
+### Feature Flags
+
+There are some features, which are quite opinionated. To make those work for
+everyone, *aws-nuke* has flags to manually enable those features. These can be
+configured on the root-level of the config, like this:
+
+```yaml
+---
+feature-flags:
+  disable-deletion-protection:
+    RDSInstance: true
+```
+
+
 ### Filtering Resources
 
 It is possible to filter this is important for not deleting the current user

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -166,6 +166,11 @@ func (n *Nuke) Scan() error {
 
 		items := Scan(region, resourceTypes)
 		for item := range items {
+			ffGetter, ok := item.Resource.(resources.FeatureFlagGetter)
+			if ok {
+				ffGetter.FeatureFlags(n.Config.FeatureFlags)
+			}
+
 			queue = append(queue, item)
 			err := n.Filter(item)
 			if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,13 @@ type Nuke struct {
 	Accounts         map[string]Account           `yaml:"accounts"`
 	ResourceTypes    ResourceTypes                `yaml:"resource-types"`
 	Presets          map[string]PresetDefinitions `yaml:"presets"`
+	FeatureFlags     FeatureFlags                 `yaml:"feature-flags"`
+}
+
+type FeatureFlags struct {
+	DisableDeletionProtection struct {
+		RDSInstance bool `yaml:"RDSInstance"`
+	} `yaml:"disable-deletion-protection"`
 }
 
 type PresetDefinitions struct {

--- a/resources/interface.go
+++ b/resources/interface.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/rebuy-de/aws-nuke/pkg/config"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
@@ -28,6 +29,11 @@ type LegacyStringer interface {
 type ResourcePropertyGetter interface {
 	Resource
 	Properties() types.Properties
+}
+
+type FeatureFlagGetter interface {
+	Resource
+	FeatureFlags(config.FeatureFlags)
 }
 
 var resourceListers = make(ResourceListers)


### PR DESCRIPTION
> Emerged from https://github.com/rebuy-de/aws-nuke/pull/417

This introduces Feature Flags, which can be enabled on config-level. As an example I made a flag for disabling the RDS Instance Protection, which makes this a breaking change (but a non-destructive one).

Additionally I added some more properties for RDS Instances.