### PR TITLE
Add --quiet flag to remove filtered resources from output

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -169,7 +169,9 @@ func (n *Nuke) Scan() error {
 				return err
 			}
 
-			item.Print()
+			if item.State != ItemStateFiltered || !n.Parameters.Quiet {
+				item.Print()
+			}
 		}
 	}
 

--- a/cmd/params.go
+++ b/cmd/params.go
@@ -14,6 +14,7 @@ type NukeParameters struct {
 	NoDryRun   bool
 	Force      bool
 	ForceSleep int
+	Quiet      bool
 
 	MaxWaitRetries int
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
 	"os"
+	"sort"
 
 	"github.com/rebuy-de/aws-nuke/pkg/awsutil"
 	"github.com/rebuy-de/aws-nuke/pkg/config"
@@ -134,6 +134,9 @@ func NewRootCommand() *cobra.Command {
 		&params.MaxWaitRetries, "max-wait-retries", 0,
 		"If specified, the program will exit if resources are stuck in waiting for this many iterations. "+
 			"0 (default) disables early exit.")
+	command.PersistentFlags().BoolVarP(
+		&params.Quiet, "quiet", "q", false,
+		"Don't show filtered resources.")
 
 	command.AddCommand(NewVersionCommand())
 	command.AddCommand(NewResourceTypesCommand())

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type NukeParameters struct {
 	NoDryRun   bool
 	Force      bool
 	ForceSleep int
+	Quiet      bool
 
 	MaxWaitRetries int
 }


### PR DESCRIPTION
Without this change, output showing what is (or will be) removed can
easily be lost on the output showing filtered resources.  It's useful
to be able to just see what is (or will be) affected in order to focus
on that.