### PR TITLE
Add support for Athena WorkGroups and NamedQueries

### DIFF
--- a/resources/athena-named-queries.go
+++ b/resources/athena-named-queries.go
@@ -1,0 +1,78 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+func init() {
+	register("AthenaNamedQuery", ListAthenaNamedQueries)
+}
+
+type AthenaNamedQuery struct {
+	svc *athena.Athena
+	id  *string
+}
+
+func ListAthenaNamedQueries(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	// List WorkGroup
+	var workgroupNames []*string
+	err := svc.ListWorkGroupsPages(
+		&athena.ListWorkGroupsInput{},
+		func(page *athena.ListWorkGroupsOutput, lastPage bool) bool {
+			for _, workgroup := range page.WorkGroups {
+				workgroupNames = append(workgroupNames, workgroup.Name)
+			}
+			return true
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// List NamedQueries or each WorkGroup
+	var namedQueryIDs []*string
+	for _, wgName := range workgroupNames {
+		err := svc.ListNamedQueriesPages(
+			&athena.ListNamedQueriesInput{WorkGroup: wgName},
+			func(page *athena.ListNamedQueriesOutput, lastPage bool) bool {
+				namedQueryIDs = append(namedQueryIDs, page.NamedQueryIds...)
+				return true
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create AthenaNamedQuery resource objects
+	for _, id := range namedQueryIDs {
+		resources = append(resources, &AthenaNamedQuery{
+			svc: svc,
+			id:  id,
+		})
+	}
+
+	return resources, err
+}
+
+func (a *AthenaNamedQuery) Remove() error {
+	_, err := a.svc.DeleteNamedQuery(&athena.DeleteNamedQueryInput{
+		NamedQueryId: a.id,
+	})
+
+	return err
+}
+
+func (a *AthenaNamedQuery) Properties() types.Properties {
+	return types.NewProperties().
+		Set("Id", *a.id)
+}
+
+func (a *AthenaNamedQuery) String() string {
+	return *a.id
+}

--- a/resources/athena-work-groups.go
+++ b/resources/athena-work-groups.go
@@ -1,0 +1,168 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	register("AthenaWorkGroup", ListAthenaWorkGroups)
+}
+
+type AthenaWorkGroup struct {
+	svc  *athena.Athena
+	name *string
+	arn  *string
+}
+
+func ListAthenaWorkGroups(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	// Lookup current account ID
+	stsSvc := sts.New(sess)
+	callerID, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, err
+	}
+	accountID := callerID.Account
+	region := svc.Config.Region
+
+	// List WorkGroup
+	var workgroupNames []*string
+	err = svc.ListWorkGroupsPages(
+		&athena.ListWorkGroupsInput{},
+		func(page *athena.ListWorkGroupsOutput, lastPage bool) bool {
+			for _, workgroup := range page.WorkGroups {
+				workgroupNames = append(workgroupNames, workgroup.Name)
+			}
+			return true
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create AthenaWorkGroup resource objects
+	for _, name := range workgroupNames {
+		resources = append(resources, &AthenaWorkGroup{
+			svc:  svc,
+			name: name,
+			// The GetWorkGroup API doesn't return an ARN,
+			// so we need to construct one ourselves
+			arn: aws.String(fmt.Sprintf(
+				"arn:aws:athena:%s:%s:workgroup/%s",
+				*region, *accountID, *name,
+			)),
+		})
+	}
+
+	return resources, err
+}
+
+func (a *AthenaWorkGroup) Remove() error {
+	// Primary WorkGroup cannot be deleted,
+	// but we can reset it to a clean state
+	if *a.name == "primary" {
+		logrus.Info("Primary Athena WorkGroup may not be deleted. Resetting configuration only.")
+
+		// Reset the configuration to its default state
+		_, err := a.svc.UpdateWorkGroup(&athena.UpdateWorkGroupInput{
+			// See https://docs.aws.amazon.com/athena/latest/APIReference/API_WorkGroupConfigurationUpdates.html
+			// for documented defaults
+			ConfigurationUpdates: &athena.WorkGroupConfigurationUpdates{
+				EnforceWorkGroupConfiguration:    aws.Bool(false),
+				PublishCloudWatchMetricsEnabled:  aws.Bool(false),
+				RemoveBytesScannedCutoffPerQuery: aws.Bool(true),
+				RequesterPaysEnabled:             aws.Bool(false),
+				ResultConfigurationUpdates:       &athena.ResultConfigurationUpdates{
+					RemoveEncryptionConfiguration: aws.Bool(true),
+					RemoveOutputLocation:          aws.Bool(true),
+				},
+			},
+			Description: aws.String(""),
+			WorkGroup:   a.name,
+		})
+
+		// Remove any tags
+		wgTagsRes, err := a.svc.ListTagsForResource(&athena.ListTagsForResourceInput{
+			ResourceARN: a.arn,
+		})
+		if err != nil {
+			return err
+		}
+		var tagKeys []*string
+		for _, tag := range wgTagsRes.Tags {
+			tagKeys = append(tagKeys, tag.Key)
+		}
+		_, err = a.svc.UntagResource(&athena.UntagResourceInput{
+			ResourceARN: a.arn,
+			TagKeys:     tagKeys,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	_, err := a.svc.DeleteWorkGroup(&athena.DeleteWorkGroupInput{
+		RecursiveDeleteOption: aws.Bool(true),
+		WorkGroup:             a.name,
+	})
+
+	return err
+}
+
+func (a *AthenaWorkGroup) Filter() error {
+	// If this is the primary work group,
+	// check if it's already had its configuration reset
+	if *a.name == "primary" {
+		// Get workgroup configuration
+		wgConfigRes, err := a.svc.GetWorkGroup(&athena.GetWorkGroupInput{
+			WorkGroup: a.name,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Get workgroup tags
+		wgTagsRes, err := a.svc.ListTagsForResource(&athena.ListTagsForResourceInput{
+			ResourceARN: a.arn,
+		})
+		if err != nil {
+			return err
+		}
+
+		// If the workgroup is already in a "clean" state, then
+		// don't add it to our plan
+		wgConfig := wgConfigRes.WorkGroup.Configuration
+		isCleanConfig := wgConfig.BytesScannedCutoffPerQuery == nil &&
+			*wgConfig.EnforceWorkGroupConfiguration == false &&
+			*wgConfig.PublishCloudWatchMetricsEnabled == false &&
+			*wgConfig.RequesterPaysEnabled == false &&
+			*wgConfig.ResultConfiguration == athena.ResultConfiguration{} &&
+			len(wgTagsRes.Tags) == 0
+
+		if isCleanConfig {
+			return errors.New("cannot delete primary athena work group")
+		}
+	}
+	return nil
+}
+
+func (a *AthenaWorkGroup) Properties() types.Properties {
+	return types.NewProperties().
+		Set("Name", *a.name).
+		Set("ARN", *a.arn)
+}
+
+func (a *AthenaWorkGroup) String() string {
+	return *a.name
+}


### PR DESCRIPTION
## Proposed Changes

Add support for deleting Athena WorkGroups and NamedQueries. Resolves #464 

Note that WorkGroups and NamedQueries are the only two modifiable Athena resources. See https://docs.aws.amazon.com/cli/latest/reference/athena/index.html

Adding some complexity here: there's a default `"primary"` WorkGroup in Athena that can't be deleted. So in order to meet our business requirements of getting accounts back in a "clean" state, the aws-nuke `WorkGroup` resource will modify the `"primary"` WorkGroup to get it back in its original state.

## Verification

I tested this out by creating some Athena resources via the web console, then running aws-nuke.
Selected aws-nuke output:

```

us-east-1 - AthenaNamedQuery - 522280c2-d6ad-4fd5-a8f5-eb041dc55e44 - [Id: "522280c2-d6ad-4fd5-a8f5-eb041dc55e44"] - would remove
us-east-1 - AthenaNamedQuery - fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4 - [Id: "fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4"] - would remove
us-east-1 - S3Bucket - s3://athena3-<UID> - [Name: "athena3-<UID>"] - would remove
us-east-1 - GlueDatabase - db - would remove
us-east-1 - GlueDatabase - default - would remove
us-east-1 - GlueDatabase - mydb - would remove
us-east-1 - AthenaWorkGroup - primary - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/primary", Name: "primary"] - would remove
us-east-1 - AthenaWorkGroup - test - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/test", Name: "test"] - would remove
Scan complete: 136 total, 8 nukeable, 128 filtered.
Do you really want to nuke these resources on the account with the ID 123456789012 and the alias 'my-account'?
Do you want to continue? Enter account alias to continue.
> my-account

us-east-1 - GlueDatabase - db - triggered remove
us-east-1 - GlueDatabase - default - triggered remove
us-east-1 - GlueDatabase - mydb - triggered remove
us-east-1 - S3Bucket - s3://athena3-<UID> - [Name: "athena3-<UID>"] - triggered remove
INFO[0027] Primary Athena WorkGroup may not be deleted. Resetting configuration only. 
us-east-1 - AthenaWorkGroup - primary - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/primary", Name: "primary"] - triggered remove
us-east-1 - AthenaWorkGroup - test - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/test", Name: "test"] - triggered remove
us-east-1 - AthenaNamedQuery - 522280c2-d6ad-4fd5-a8f5-eb041dc55e44 - [Id: "522280c2-d6ad-4fd5-a8f5-eb041dc55e44"] - triggered remove
us-east-1 - AthenaNamedQuery - fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4 - [Id: "fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4"] - triggered remove

Removal requested: 8 waiting, 0 failed, 128 skipped, 0 finished

us-east-1 - GlueDatabase - db - waiting
us-east-1 - GlueDatabase - default - waiting
us-east-1 - GlueDatabase - mydb - waiting
us-east-1 - S3Bucket - s3://athena3-<UID> - [Name: "athena3-<UID>"] - waiting
us-east-1 - AthenaWorkGroup - primary - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/primary", Name: "primary"] - waiting
us-east-1 - AthenaWorkGroup - test - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/test", Name: "test"] - waiting
us-east-1 - AthenaNamedQuery - 522280c2-d6ad-4fd5-a8f5-eb041dc55e44 - [Id: "522280c2-d6ad-4fd5-a8f5-eb041dc55e44"] - waiting
us-east-1 - AthenaNamedQuery - fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4 - [Id: "fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4"] - waiting

Removal requested: 8 waiting, 0 failed, 128 skipped, 0 finished

us-east-1 - GlueDatabase - db - removed
us-east-1 - GlueDatabase - default - removed
us-east-1 - GlueDatabase - mydb - removed
us-east-1 - S3Bucket - s3://athena3-<UID> - [Name: "athena3-<UID>"] - removed
us-east-1 - AthenaWorkGroup - primary - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/primary", Name: "primary"] - removed
us-east-1 - AthenaWorkGroup - test - [ARN: "arn:aws:athena:us-east-1:123456789012:workgroup/test", Name: "test"] - removed
us-east-1 - AthenaNamedQuery - 522280c2-d6ad-4fd5-a8f5-eb041dc55e44 - [Id: "522280c2-d6ad-4fd5-a8f5-eb041dc55e44"] - removed
us-east-1 - AthenaNamedQuery - fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4 - [Id: "fec27c1d-96ed-4bd2-bd36-0fbe5c9fc9e4"] - removed

Removal requested: 0 waiting, 0 failed, 128 skipped, 8 finished

Nuke complete: 0 failed, 128 skipped, 8 finished.
