### PR TITLE
add route53 health check resource

### DIFF
--- a/resources/route53-health-checks.go
+++ b/resources/route53-health-checks.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+func init() {
+	register("Route53HealthCheck", ListRoute53HealthChecks)
+}
+
+func ListRoute53HealthChecks(sess *session.Session) ([]Resource, error) {
+	svc := route53.New(sess)
+	params := &route53.ListHealthChecksInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListHealthChecks(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, check := range resp.HealthChecks {
+		resources = append(resources, &Route53HealthCheck{
+			svc:  svc,
+			id:   check.Id,
+		})
+	}
+
+	return resources, nil
+}
+
+type Route53HealthCheck struct {
+	svc  *route53.Route53
+	id   *string
+}
+
+func (hz *Route53HealthCheck) Remove() error {
+	params := &route53.DeleteHealthCheckInput{
+		HealthCheckId: hz.id,
+	}
+
+	_, err := hz.svc.DeleteHealthCheck(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (hz *Route53HealthCheck) Properties() types.Properties {
+	return types.NewProperties().
+		Set("ID", hz.id)
+}
+
+func (hz *Route53HealthCheck) String() string {
+	return fmt.Sprintf("%s", *hz.id)
+}


### PR DESCRIPTION
This adds support for nuking Route53 health checks.

Sample output:
```bash
global - Route53HealthCheck - 483e892d-2508-4d94-bd6f-c93899a227d5 - [ID: "483e892d-2508-4d94-bd6f-c93899a227d5"] - removed
global - Route53HealthCheck - 5a3da0e5-b75d-4361-9e14-4dc43791520b - [ID: "5a3da0e5-b75d-4361-9e14-4dc43791520b"] - removed
global - Route53HealthCheck - 922e3b9b-0fcf-4563-926c-20c2584687db - [ID: "922e3b9b-0fcf-4563-926c-20c2584687db"] - removed
global - Route53HealthCheck - 9958f9d6-5b82-42c5-a6fb-e76569ac3ff7 - [ID: "9958f9d6-5b82-42c5-a6fb-e76569ac3ff7"] - removed
global - Route53HealthCheck - a1ef5f16-d575-4ac3-b3a5-c08a3702ff7f - [ID: "a1ef5f16-d575-4ac3-b3a5-c08a3702ff7f"] - removed
global - Route53HealthCheck - bbf4907a-00f9-4e45-b9d0-a3103e03996a - [ID: "bbf4907a-00f9-4e45-b9d0-a3103e03996a"] - removed
global - Route53HealthCheck - ce06950d-6165-459a-89e8-c6415fe92c66 - [ID: "ce06950d-6165-459a-89e8-c6415fe92c66"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 7 finished

Nuke complete: 0 failed, 0 skipped, 7 finished.
```