### PR TITLE
feat: Add OwnerId Prop to EC2TGW

### DIFF
--- a/resources/ec2-tgw.go
+++ b/resources/ec2-tgw.go
@@ -72,7 +72,10 @@ func (e *EC2TGW) Properties() types.Properties {
 	for _, tagValue := range e.tgw.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
-	properties.Set("ID", e.tgw.TransitGatewayId)
+	properties.
+		Set("ID", e.tgw.TransitGatewayId).
+		Set("OwnerId", e.tgw.OwnerId)
+
 	return properties
 }
 


### PR DESCRIPTION
Adds the OwnerId property to EC2TGW.  Something required when the TGWs are shared out at an Org level and can not be removed from sub-accounts.