### PR TITLE
Replace Regex in S3Object sample to recursive nuke

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -34,7 +34,7 @@ accounts:
       - "s3://my-bucket"
       S3Object:
       - type: "glob"
-        value: "s3://my-bucket/*"
+        value: "s3://my-bucket/**"
       Route53HostedZone:
       - property: Name
         type: "glob"


### PR DESCRIPTION
Replace the wildcard to ** to allow recurside sublevel directories in
the nuke process.