### PR TITLE
Support for ApplicationAutoScaling - ScalableTargets

### DIFF
--- a/resources/applicationautoscaling-scalabletargets.go
+++ b/resources/applicationautoscaling-scalabletargets.go
@@ -1,0 +1,85 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+)
+
+func init() {
+	register("ApplicationAutoScalingScalableTarget", ListApplicationAutoScalingScalableTargets)
+}
+
+func ListApplicationAutoScalingScalableTargets(s *session.Session) ([]Resource, error) {
+	svc := applicationautoscaling.New(s)
+
+	// https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#autoscaling-RegisterScalableTarget-request-ServiceNamespace
+	namespaces := []string{
+		"ecs",
+		"elasticmapreduce",
+		"ec2",
+		"appstream",
+		"dynamodb",
+		"rds",
+		"sagemaker",
+		"custom-resource",
+		"comprehend",
+		"lambda",
+	}
+
+	resources := make([]Resource, 0)
+
+	for _, namespace := range namespaces {
+		params := &applicationautoscaling.DescribeScalableTargetsInput{
+			ServiceNamespace: &namespace,
+		}
+
+		for {
+			resp, err := svc.DescribeScalableTargets(params)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, aasst := range resp.ScalableTargets {
+				resources = append(resources, &ApplicationAutoScalingScalableTarget{
+					svc:               svc,
+					resourceId:        aasst.ResourceId,
+					scalableDimension: aasst.ScalableDimension,
+					serviceNamespace:  aasst.ServiceNamespace,
+				})
+			}
+
+			if resp.NextToken == nil {
+				break
+			}
+	
+			params.NextToken = resp.NextToken
+		}
+	}
+	return resources, nil
+}
+
+type ApplicationAutoScalingScalableTarget struct {
+	svc               *applicationautoscaling.ApplicationAutoScaling
+	resourceId        *string
+	scalableDimension *string
+	serviceNamespace  *string
+}
+
+func (aasst *ApplicationAutoScalingScalableTarget) Remove() error {
+	params := &applicationautoscaling.DeregisterScalableTargetInput{
+		ResourceId:        aasst.resourceId,
+		ScalableDimension: aasst.scalableDimension,
+		ServiceNamespace:  aasst.serviceNamespace,
+	}
+
+	_, err := aasst.svc.DeregisterScalableTarget(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (aasst *ApplicationAutoScalingScalableTarget) String() string {
+	return *aasst.resourceId
+}

--- a/resources/applicationautoscaling-scalabletargets.go
+++ b/resources/applicationautoscaling-scalabletargets.go
@@ -14,16 +14,16 @@ func ListApplicationAutoScalingScalableTargets(s *session.Session) ([]Resource, 
 
 	// https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#autoscaling-RegisterScalableTarget-request-ServiceNamespace
 	namespaces := []string{
+		"appstream",
+		"comprehend",
+		"custom-resource",
+		"dynamodb",
+		"ec2",
 		"ecs",
 		"elasticmapreduce",
-		"ec2",
-		"appstream",
-		"dynamodb",
+		"lambda",
 		"rds",
 		"sagemaker",
-		"custom-resource",
-		"comprehend",
-		"lambda",
 	}
 
 	resources := make([]Resource, 0)


### PR DESCRIPTION
Resources such as dynamodb (sometimes?) leave behind `ScalableTargets` when deleted. Since there is a limit on how many of them can be on each account, we should support deleting them.

I couldn't find a programmatic way to find out all applicable `namespaces`, so I just hardcoded them.