### PR TITLE
Generate mocks before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ been tested for a while.
 
 You can find Linux and macOS binaries on the
 [releases page](https://github.com/rebuy-de/aws-nuke/releases), but we also
-provide containerized versions on [quay.io/rebuy/aws-nuke](quay.io/rebuy/aws-nuke)
+provide containerized versions on [quay.io/rebuy/aws-nuke](https://quay.io/rebuy/aws-nuke)
 and [docker.io/rebuy/aws-nuke](https://hub.docker.com/r/rebuy/aws-nuke) (mirror).
 
 

--- a/golang.mk
+++ b/golang.mk
@@ -35,7 +35,7 @@ vendor: go.mod go.sum
 format:
 	gofmt -s -w $(GOFILES)
 
-vet: vendor
+vet: go_generate vendor
 	go vet $(GOPKGS)
 
 lint:
@@ -45,13 +45,13 @@ go_generate:
 	rm -rvf mocks
 	go generate ./...
 
-test_packages: vendor
+test_packages: go_generate vendor
 	go test $(GOPKGS)
 
 test_format:
 	gofmt -s -l $(GOFILES)
 
-test: test_format go_generate vet lint test_packages
+test: test_format vet lint test_packages
 
 cov: go_generate
 	gocov test -v $(GOPKGS) \
@@ -65,17 +65,17 @@ _build: vendor
 		$(TARGET);\
 	)
 
-build: _build
+build: go_generate _build
 	$(foreach TARGET,$(TARGETS),ln -sf $(OUTPUT_FILE) dist/$(OUTPUT_LINK);)
 
 compress: _build
 	tar czf dist/$(OUTPUT_FILE).tar.gz dist/$(OUTPUT_FILE)
 
-xc:
+xc: go_generate
 	GOOS=linux GOARCH=amd64 make compress
 	GOOS=darwin GOARCH=amd64 make compress
 
-install: vendor test
+install: test
 	$(foreach TARGET,$(TARGETS),go install \
 		$(BUILD_FLAGS);)
 


### PR DESCRIPTION
After a [hint on the mailing list](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/aws-nuke/KmmMHDwf2oc/5ubmgoC3AQAJ) we noticed that the default `make` command doesn't work anymore because the mocks are missing. This should fix it.