### PR TITLE
Fix presets filter example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ presets:
       DynamoDBTable:
       - "terraform-lock"
   common:
-    filter:
+    filters:
       IAMRole:
       - "OrganizationAccountAccessRole"
 ```


### PR DESCRIPTION
There was a typo, using `presets.common.filter` instead of `presets.common.filters` actually fails to parse.