### PR TITLE
Handle if the route table is deleted between discovery and removal

### DIFF
--- a/generate_mocks
+++ b/generate_mocks
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 go run github.com/golang/mock/mockgen -source $(go list -m -f "{{.Dir}}" "github.com/aws/aws-sdk-go")/service/cloudformation/cloudformationiface/interface.go -destination mocks/mock_cloudformationiface/mock.go
+go run github.com/golang/mock/mockgen -source $(go list -m -f "{{.Dir}}" "github.com/aws/aws-sdk-go")/service/ec2/ec2iface/interface.go -destination mocks/mock_ec2iface/mock.go

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -1,13 +1,15 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2RouteTable struct {
-	svc        *ec2.EC2
+	svc        ec2iface.EC2API
 	routeTable *ec2.RouteTable
 }
 
@@ -41,6 +43,11 @@ func (e *EC2RouteTable) Remove() error {
 
 	_, err := e.svc.DeleteRouteTable(params)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "InvalidRouteTableID.NotFound" { //the route table was deleted elsewhere
+				return nil
+			}
+		}
 		return err
 	}
 

--- a/resources/ec2-route-tables_test.go
+++ b/resources/ec2-route-tables_test.go
@@ -1,0 +1,56 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/rebuy-de/aws-nuke/mocks/mock_ec2iface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEC2RouteTable_Delete(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEc2 := mock_ec2iface.NewMockEC2API(ctrl)
+
+	routeTable := EC2RouteTable{
+		svc: mockEc2,
+		routeTable: &ec2.RouteTable{
+			RouteTableId: aws.String("foo1"),
+		},
+	}
+
+	mockEc2.EXPECT().DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+		RouteTableId: aws.String("foo1"),
+	})).Return(&ec2.DeleteRouteTableOutput{}, nil)
+
+	err := routeTable.Remove()
+	a.Nil(err)
+}
+
+func TestEC2RouteTable_Delete_NotFound(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEc2 := mock_ec2iface.NewMockEC2API(ctrl)
+
+	routeTable := EC2RouteTable{
+		svc: mockEc2,
+		routeTable: &ec2.RouteTable{
+			RouteTableId: aws.String("foo1"),
+		},
+	}
+
+	mockEc2.EXPECT().DeleteRouteTable(gomock.Eq(&ec2.DeleteRouteTableInput{
+		RouteTableId: aws.String("foo1"),
+	})).Return(nil, awserr.New("InvalidRouteTableID.NotFound", "foo", nil))
+
+	err := routeTable.Remove()
+	a.Nil(err)
+}


### PR DESCRIPTION
This might happen if cloudformation was managing the route table