### PR TITLE
remove anonymous feature flag struct

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,11 +33,13 @@ type Nuke struct {
 }
 
 type FeatureFlags struct {
-	DisableDeletionProtection struct {
-		RDSInstance         bool `yaml:"RDSInstance"`
-		EC2Instance         bool `yaml:"EC2Instance"`
-		CloudformationStack bool `yaml:"CloudformationStack"`
-	} `yaml:"disable-deletion-protection"`
+	DisableDeletionProtection DisableDeletionProtection `yaml:"disable-deletion-protection"`
+}
+
+type DisableDeletionProtection struct {
+	RDSInstance         bool `yaml:"RDSInstance"`
+	EC2Instance         bool `yaml:"EC2Instance"`
+	CloudformationStack bool `yaml:"CloudformationStack"`
 }
 
 type PresetDefinitions struct {


### PR DESCRIPTION
anonymous structs require one to specify the whole struct signature when
setting the flags

We use this as a library from our own application.