### PR TITLE
Build binaries for Windows & ARM64

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -70,10 +70,13 @@ build: go_generate _build
 
 compress: _build
 	tar czf dist/$(OUTPUT_FILE).tar.gz dist/$(OUTPUT_FILE)
+	rm -f dist/$(OUTPUT_FILE)
 
 xc: go_generate
 	GOOS=linux GOARCH=amd64 make compress
+	GOOS=linux GOARCH=arm64 make compress
 	GOOS=darwin GOARCH=amd64 make compress
+	GOOS=windows GOARCH=amd64 make compress
 
 install: test
 	$(foreach TARGET,$(TARGETS),go install \

--- a/golang.mk
+++ b/golang.mk
@@ -69,7 +69,7 @@ build: go_generate _build
 	$(foreach TARGET,$(TARGETS),ln -sf $(OUTPUT_FILE) dist/$(OUTPUT_LINK);)
 
 compress: _build
-	tar czf dist/$(OUTPUT_FILE).tar.gz dist/$(OUTPUT_FILE)
+	tar czf dist/$(OUTPUT_FILE).tar.gz -C dist $(OUTPUT_FILE)
 	rm -f dist/$(OUTPUT_FILE)
 
 xc: go_generate

--- a/golang.mk
+++ b/golang.mk
@@ -23,7 +23,7 @@ BUILD_FLAGS=-ldflags "\
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
 GOPKGS=$(shell go list ./...)
 
-OUTPUT_FILE=$(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)$(shell go env GOEXE)
+OUTPUT_FILE=$(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)$(shell go env GOARM)$(shell go env GOEXE)
 OUTPUT_LINK=$(NAME)$(shell go env GOEXE)
 
 default: build
@@ -75,6 +75,7 @@ compress: _build
 xc: go_generate
 	GOOS=linux GOARCH=amd64 make compress
 	GOOS=linux GOARCH=arm64 make compress
+	GOOS=linux GOARCH=arm GOARM=7 make compress
 	GOOS=darwin GOARCH=amd64 make compress
 	GOOS=windows GOARCH=amd64 make compress
 


### PR DESCRIPTION
@rebuy-de/prp-aws-nuke What's your opinion on this? 
1. Remove unpacked binaries in the `make compress` step to clean up our [release assets](https://github.com/rebuy-de/aws-nuke/releases/tag/v2.15.0-beta.1)
2. Build binaries for Windows and ARM64/ARMv7 linux
3. Remove `dist` path from archives when unpacking