### PR TITLE
Enable CLICOLOR and CLICOLOR_FORCE env variables

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,9 @@ func NewRootCommand() *cobra.Command {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
 		}
+		log.SetFormatter(&log.TextFormatter{
+			EnvironmentOverrideColors: true,
+		})
 	}
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This allows forcing color output as described in https://bixense.com/clicolors/ . This is useful when using aws-nuke in CI jobs.