### PR TITLE
Allow to nuke Cognito's Identity Providers

### DIFF
--- a/resources/cognito-identity-providers.go
+++ b/resources/cognito-identity-providers.go
@@ -1,0 +1,90 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+type CognitoIdentityProvider struct {
+	svc          *cognitoidentityprovider.CognitoIdentityProvider
+	name         *string
+	providerType *string
+	userPoolName *string
+	userPoolId   *string
+}
+
+func init() {
+	register("CognitoIdentityProvider", ListCognitoIdentityProviders)
+}
+
+func ListCognitoIdentityProviders(sess *session.Session) ([]Resource, error) {
+	svc := cognitoidentityprovider.New(sess)
+
+	userPools, poolErr := ListCognitoUserPools(sess)
+	if poolErr != nil {
+		return nil, poolErr
+	}
+
+	resources := []Resource{}
+
+	for _, userPoolResource := range userPools {
+		userPool, ok := userPoolResource.(*CognitoUserPool)
+		if !ok {
+			logrus.Errorf("Unable to case CognitoUserPool")
+			continue
+		}
+
+		listParams := &cognitoidentityprovider.ListIdentityProvidersInput{
+			UserPoolId: userPool.id,
+			MaxResults: aws.Int64(50),
+		}
+
+		for {
+			output, err := svc.ListIdentityProviders(listParams)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, provider := range output.Providers {
+				resources = append(resources, &CognitoIdentityProvider{
+					svc:          svc,
+					name:         provider.ProviderName,
+					providerType: provider.ProviderType,
+					userPoolName: userPool.name,
+					userPoolId:   userPool.id,
+				})
+			}
+
+			if output.NextToken == nil {
+				break
+			}
+
+			listParams.NextToken = output.NextToken
+		}
+	}
+
+	return resources, nil
+}
+
+func (p *CognitoIdentityProvider) Remove() error {
+
+	_, err := p.svc.DeleteIdentityProvider(&cognitoidentityprovider.DeleteIdentityProviderInput{
+		UserPoolId:   p.userPoolId,
+		ProviderName: p.name,
+	})
+
+	return err
+}
+
+func (p *CognitoIdentityProvider) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Type", p.providerType)
+	return properties
+}
+
+func (p *CognitoIdentityProvider) String() string {
+	return *p.userPoolName + " -> " + *p.name
+}

--- a/resources/cognito-identity-providers.go
+++ b/resources/cognito-identity-providers.go
@@ -82,6 +82,8 @@ func (p *CognitoIdentityProvider) Remove() error {
 func (p *CognitoIdentityProvider) Properties() types.Properties {
 	properties := types.NewProperties()
 	properties.Set("Type", p.providerType)
+	properties.Set("UserPoolName", p.userPoolName)
+	properties.Set("Name", p.name)
 	return properties
 }
 


### PR DESCRIPTION
```
$ ./aws-nuke --config aws-nuke.config.yaml --target CognitoIdentityProvider
aws-nuke version unknown - unknown - unknown

Do you really want to nuke the account with the ID 123456789 and the alias 'toto123'?
Do you want to continue? Enter account alias to continue.
> toto123

eu-central-1 - CognitoIdentityProvider - pool1 -> provider1 - [Type: "OIDC"] - would remove
eu-central-1 - CognitoIdentityProvider - pool1 -> provider2 - [Type: "OIDC"] - would remove
Scan complete: 2 total, 2 nukeable, 0 filtered.

The above resources would be deleted with the supplied configuration. Provide --no-dry-run to actually destroy resources.
```