### PR TITLE
Nuke Cognito user pool clients (aka. "App clients")

### DIFF
--- a/resources/cognito-userpool-clients.go
+++ b/resources/cognito-userpool-clients.go
@@ -1,0 +1,92 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+type CognitoUserPoolClient struct {
+	svc          *cognitoidentityprovider.CognitoIdentityProvider
+	name         *string
+	id           *string
+	userPoolName *string
+	userPoolId   *string
+}
+
+func init() {
+	register("CognitoUserPoolClient", ListCognitoUserPoolClients)
+}
+
+func ListCognitoUserPoolClients(sess *session.Session) ([]Resource, error) {
+	svc := cognitoidentityprovider.New(sess)
+
+	userPools, poolErr := ListCognitoUserPools(sess)
+	if poolErr != nil {
+		return nil, poolErr
+	}
+
+	resources := []Resource{}
+
+	for _, userPoolResource := range userPools {
+		userPool, ok := userPoolResource.(*CognitoUserPool)
+		if !ok {
+			logrus.Errorf("Unable to case CognitoUserPool")
+			continue
+		}
+
+		listParams := &cognitoidentityprovider.ListUserPoolClientsInput{
+			UserPoolId: userPool.id,
+			MaxResults: aws.Int64(50),
+		}
+
+		for {
+			output, err := svc.ListUserPoolClients(listParams)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, client := range output.UserPoolClients {
+				resources = append(resources, &CognitoUserPoolClient{
+					svc:          svc,
+					id:           client.ClientId,
+					name:         client.ClientName,
+					userPoolName: userPool.name,
+					userPoolId:   userPool.id,
+				})
+			}
+
+			if output.NextToken == nil {
+				break
+			}
+
+			listParams.NextToken = output.NextToken
+		}
+	}
+
+	return resources, nil
+}
+
+func (p *CognitoUserPoolClient) Remove() error {
+
+	_, err := p.svc.DeleteUserPoolClient(&cognitoidentityprovider.DeleteUserPoolClientInput{
+		ClientId:   p.id,
+		UserPoolId: p.userPoolId,
+	})
+
+	return err
+}
+
+func (p *CognitoUserPoolClient) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", p.id)
+	properties.Set("Name", p.name)
+	properties.Set("UserPoolName", p.userPoolName)
+	return properties
+}
+
+func (p *CognitoUserPoolClient) String() string {
+	return *p.userPoolName + " -> " + *p.name
+}


### PR DESCRIPTION
```
$ ./aws-nuke --config aws-nuke.config.yaml --target CognitoUserPoolClient
aws-nuke version unknown - unknown - unknown

Do you really want to nuke the account with the ID 123456789 and the alias 'toto123'?
Do you want to continue? Enter account alias to continue.
> toto123

eu-central-1 - CognitoUserPoolClient - toto123 -> test - [ID: "6ta7tgstig218mfq3i529d5eq9", Name: "test", UserPoolName: "toto123"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID 123456789 and the alias 'toto123'?
Do you want to continue? Enter account alias to continue.
> toto123

eu-central-1 - CognitoUserPoolClient - toto123 -> test - [ID: "6ta7tgstig218mfq3i529d5eq9", Name: "test", UserPoolName: "toto123"] - triggered remove

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

eu-central-1 - CognitoUserPoolClient - toto123 -> test - [ID: "6ta7tgstig218mfq3i529d5eq9", Name: "test", UserPoolName: "toto123"] - waiting

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

eu-central-1 - CognitoUserPoolClient - toto123 -> test - [ID: "6ta7tgstig218mfq3i529d5eq9", Name: "test", UserPoolName: "toto123"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished

Nuke complete: 0 failed, 0 skipped, 1 finished.
```