### PR TITLE
Build multiarch docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
 
   docker_build:
     runs-on: ubuntu-20.04
-    name: Docker build
+    name: Docker Build
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     - name: Generate image tags
       shell: bash
       run: |
-        if [ "${GITHUB_EVENT_NAME}" == "pull_request"]; then
+        if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
           echo "##[set-output name=tags;]quay.io/rebuy/aws-nuke:${GITHUB_HEAD_REF},docker.io/rebuy/aws-nuke:${GITHUB_HEAD_REF}"
         else
           echo "##[set-output name=tags;]quay.io/rebuy/aws-nuke:main,docker.io/rebuy/aws-nuke:main,\

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,55 @@ jobs:
     - name: Build Project
       run: |
         make
+
+  docker_build:
+    runs-on: ubuntu-20.04
+    name: Docker build
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Generate image tags
+      shell: bash
+      run: |
+        if [ "${GITHUB_EVENT_NAME}" == "pull_request"]; then
+          echo "##[set-output name=tags;]quay.io/rebuy/aws-nuke:${GITHUB_HEAD_REF},docker.io/rebuy/aws-nuke:${GITHUB_HEAD_REF}"
+        else
+          echo "##[set-output name=tags;]quay.io/rebuy/aws-nuke:main,docker.io/rebuy/aws-nuke:main,\
+            quay.io/rebuy/aws-nuke:latest,docker.io/rebuy/aws-nuke:latest"
+        fi
+      id: generate_tags
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64,arm/v7
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.generate_tags.outputs.tags }}
+        platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,3 +30,49 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
+
+  docker_build:
+    runs-on: ubuntu-20.04
+    name: Docker Build
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Generate image tags
+      shell: bash
+      run: echo "##[set-output name=tags;]quay.io/rebuy/aws-nuke:${GITHUB_REF#refs/tags/},docker.io/rebuy/aws-nuke:${GITHUB_REF#refs/tags/}"
+      id: generate_tags
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64,arm/v7
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.generate_tags.outputs.tags }}
+        platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Source: https://github.com/rebuy-de/golang-template
-
 FROM golang:1.16-alpine as builder
 
 RUN apk add --no-cache git make curl openssl
@@ -7,11 +5,6 @@ RUN apk add --no-cache git make curl openssl
 # Configure Go
 ENV GOPATH=/go PATH=/go/bin:$PATH CGO_ENABLED=0 GO111MODULE=on
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
-
-ENV GO111MODULE on
-# Install Go Tools
-RUN go get -u golang.org/x/lint/golint
-
 
 WORKDIR /src
 
@@ -22,7 +15,6 @@ RUN go mod download
 COPY . .
 
 RUN set -x \
- && make test \
  && make build \
  && cp /src/dist/aws-nuke /usr/local/bin/
 


### PR DESCRIPTION
This PR is building docker images for `amd64`, `arm64` and `armv7` architectures, which are pushed to quay.io and docker hub. This way we can stop relying on the separate build on quay and the following sync and we have multiarch images.