### PR TITLE
network-interfaces: detach eni before deleting

### DIFF
--- a/resources/ec2-network-interfaces.go
+++ b/resources/ec2-network-interfaces.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
@@ -36,6 +37,16 @@ func ListEC2NetworkInterfaces(sess *session.Session) ([]Resource, error) {
 }
 
 func (e *EC2NetworkInterface) Remove() error {
+	if e.eni.Attachment != nil {
+		_, err := e.svc.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
+			AttachmentId: e.eni.Attachment.AttachmentId,
+			Force:        aws.Bool(true),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	params := &ec2.DeleteNetworkInterfaceInput{
 		NetworkInterfaceId: e.eni.NetworkInterfaceId,
 	}


### PR DESCRIPTION
Network Interfaces (ENIs) can remain attached to an instance even
after the associated instance has been destroyed. ENIs in an attached
state cannot be deleted directly. They must first be detached. This
commit adds the forcible detachment of the ENI, if attached, then 
proceeds with deletion.

Thanks for aws-nuke BTW, we use it quite a bit at our company.