### PR TITLE
Use `uname -n` to get the machine's hostname

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -7,7 +7,7 @@ NAME=$(notdir $(PACKAGE))
 BUILD_VERSION=$(shell git describe --always --dirty --tags | tr '-' '.' )
 BUILD_DATE=$(shell LC_ALL=C date)
 BUILD_HASH=$(shell git rev-parse HEAD)
-BUILD_MACHINE=$(shell echo $$HOSTNAME)
+BUILD_MACHINE=$(shell uname -n)
 BUILD_USER=$(shell whoami)
 BUILD_ENVIRONMENT=$(BUILD_USER)@$(BUILD_MACHINE)
 


### PR DESCRIPTION
As the commit message says, `shell echo $$HOSTNAME` in the `Makefile` was expanding to nothing when I tried to build `aws-nuke` in WSL (with Ubuntu 20.04 as the distro). I'm pasting an excerpt from the build log where you can see the missing hostname expansion in the last line (line breaks were added by me when pasting, for readability).

I'm not sure about the reason why it wasn't working. Running `echo $HOSTNAME` in my shell did work (I don't know if it's a syntax issue as I'm not familiar with `Makefile`s). Using `uname -n` seems to fix the issue, however, which is also POSIX-compliant according to [this answer](https://unix.stackexchange.com/a/306813/222786).

The missing hostname was also reflected when I ran `aws-nuke version`, before the fix.

```
...
go build -ldflags "  -s -w -X 'github.com/rebuy-de/aws-nuke/cmd.BuildVersion=v2.15.0.rc.3'
-X 'github.com/rebuy-de/aws-nuke/cmd.BuildDate=Thu Mar 11 23:04:28 CET 2021'
-X 'github.com/rebuy-de/aws-nuke/cmd.BuildHash=0287f7d3fd4ebbc38e8ceb9ef84ae022a62c5976'
-X 'github.com/rebuy-de/aws-nuke/cmd.BuildEnvironment=gian@' " -o dist/aws-nuke-v2.15.0.rc.3-windows-amd64.exe ".";
...
```