### PR TITLE
Add properties for IAM role and group attachments (#614)

### DIFF
--- a/resources/iam-group-policy-attachments.go
+++ b/resources/iam-group-policy-attachments.go
@@ -66,7 +66,8 @@ func (e *IAMGroupPolicyAttachment) Remove() error {
 func (e *IAMGroupPolicyAttachment) Properties() types.Properties {
 	return types.NewProperties().
 		Set("RoleName", e.roleName).
-		Set("PolicyName", e.policyName)
+		Set("PolicyName", e.policyName).
+		Set("PolicyArn", e.policyArn)
 }
 
 func (e *IAMGroupPolicyAttachment) String() string {

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -94,7 +94,8 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 func (e *IAMRolePolicyAttachment) Properties() types.Properties {
 	return types.NewProperties().
 		Set("RoleName", e.roleName).
-		Set("PolicyName", e.policyName)
+		Set("PolicyName", e.policyName).
+		Set("PolicyArn", e.policyArn)
 }
 
 func (e *IAMRolePolicyAttachment) String() string {


### PR DESCRIPTION
It appears that the policy ARN wasn't exposed in IAM roles and groups attachment but yet exposed for users. For the sake of consistency, this PR add these properties to these kinds of resources.

This addresses the issue #614 