### PR TITLE
feat: adding support for nuking aws appsync graphql api resource

### DIFF
--- a/resources/appsync-graphqlapis.go
+++ b/resources/appsync-graphqlapis.go
@@ -68,6 +68,7 @@ func (f *AppSyncGraphqlAPI) Properties() types.Properties {
 		properties.SetTag(aws.String(key), value)
 	}
 	properties.Set("Name", f.name)
+	properties.Set("APIID", f.apiID)
 	return properties
 }
 

--- a/resources/appsync-graphqlapis.go
+++ b/resources/appsync-graphqlapis.go
@@ -7,8 +7,8 @@ import (
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
-// AppSyncGraphqlApi - An AWS AppSync GraphQL API
-type AppSyncGraphqlApi struct {
+// AppSyncGraphqlAPI - An AWS AppSync GraphQL API
+type AppSyncGraphqlAPI struct {
 	svc   *appsync.AppSync
 	apiID *string
 	name  *string
@@ -16,11 +16,11 @@ type AppSyncGraphqlApi struct {
 }
 
 func init() {
-	register("AppSyncGraphqlApi", ListAppSyncGraphqlApis)
+	register("AppSyncGraphqlAPI", ListAppSyncGraphqlAPIs)
 }
 
-// ListAppSyncGraphqlApis - List all AWS AppSync GraphQL APIs in the account
-func ListAppSyncGraphqlApis(sess *session.Session) ([]Resource, error) {
+// ListAppSyncGraphqlAPIs - List all AWS AppSync GraphQL APIs in the account
+func ListAppSyncGraphqlAPIs(sess *session.Session) ([]Resource, error) {
 	svc := appsync.New(sess)
 	resources := []Resource{}
 
@@ -34,12 +34,12 @@ func ListAppSyncGraphqlApis(sess *session.Session) ([]Resource, error) {
 			return nil, err
 		}
 
-		for _, graphqlApi := range resp.GraphqlApis {
-			resources = append(resources, &AppSyncGraphqlApi{
+		for _, graphqlAPI := range resp.GraphqlApis {
+			resources = append(resources, &AppSyncGraphqlAPI{
 				svc:   svc,
-				apiID: graphqlApi.ApiId,
-				name:  graphqlApi.Name,
-				tags:  graphqlApi.Tags,
+				apiID: graphqlAPI.ApiId,
+				name:  graphqlAPI.Name,
+				tags:  graphqlAPI.Tags,
 			})
 		}
 
@@ -54,7 +54,7 @@ func ListAppSyncGraphqlApis(sess *session.Session) ([]Resource, error) {
 }
 
 // Remove - remove an AWS AppSync GraphQL API
-func (f *AppSyncGraphqlApi) Remove() error {
+func (f *AppSyncGraphqlAPI) Remove() error {
 	_, err := f.svc.DeleteGraphqlApi(&appsync.DeleteGraphqlApiInput{
 		ApiId: f.apiID,
 	})
@@ -62,7 +62,7 @@ func (f *AppSyncGraphqlApi) Remove() error {
 }
 
 // Properties - Get the properties of an AWS AppSync GraphQL API
-func (f *AppSyncGraphqlApi) Properties() types.Properties {
+func (f *AppSyncGraphqlAPI) Properties() types.Properties {
 	properties := types.NewProperties()
 	for key, value := range f.tags {
 		properties.SetTag(aws.String(key), value)
@@ -71,6 +71,6 @@ func (f *AppSyncGraphqlApi) Properties() types.Properties {
 	return properties
 }
 
-func (f *AppSyncGraphqlApi) String() string {
+func (f *AppSyncGraphqlAPI) String() string {
 	return *f.apiID
 }

--- a/resources/appsync-graphqlapis.go
+++ b/resources/appsync-graphqlapis.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+// AppSyncGraphqlApi - An AWS AppSync GraphQL API
+type AppSyncGraphqlApi struct {
+	svc   *appsync.AppSync
+	apiID *string
+	name  *string
+	tags  map[string]*string
+}
+
+func init() {
+	register("AppSyncGraphqlApi", ListAppSyncGraphqlApis)
+}
+
+// ListAppSyncGraphqlApis - List all AWS AppSync GraphQL APIs in the account
+func ListAppSyncGraphqlApis(sess *session.Session) ([]Resource, error) {
+	svc := appsync.New(sess)
+	resources := []Resource{}
+
+	params := &appsync.ListGraphqlApisInput{
+		MaxResults: aws.Int64(25),
+	}
+
+	for {
+		resp, err := svc.ListGraphqlApis(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, graphqlApi := range resp.GraphqlApis {
+			resources = append(resources, &AppSyncGraphqlApi{
+				svc:   svc,
+				apiID: graphqlApi.ApiId,
+				name:  graphqlApi.Name,
+				tags:  graphqlApi.Tags,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+// Remove - remove an AWS AppSync GraphQL API
+func (f *AppSyncGraphqlApi) Remove() error {
+	_, err := f.svc.DeleteGraphqlApi(&appsync.DeleteGraphqlApiInput{
+		ApiId: f.apiID,
+	})
+	return err
+}
+
+// Properties - Get the properties of an AWS AppSync GraphQL API
+func (f *AppSyncGraphqlApi) Properties() types.Properties {
+	properties := types.NewProperties()
+	for key, value := range f.tags {
+		properties.SetTag(aws.String(key), value)
+	}
+	properties.Set("Name", f.name)
+	return properties
+}
+
+func (f *AppSyncGraphqlApi) String() string {
+	return *f.apiID
+}


### PR DESCRIPTION
This commit adds support for nuking AWS AppSync GraphQL APIs. The resource type is AppSyncGraphqlApi (following AWS SDK naming and casing). It supports filtering by API name and tags.

Example config:
```
regions:
  - us-east-1
  - global

resource-types:
  targets:
    - AppSyncGraphqlAPI

account-blocklist:
  - "999999999999" # production

accounts:
  "<redacted>": {} # aws-nuke-example
```

Example output:
```
❯ ./aws-nuke -c config.yaml --no-dry-run
aws-nuke version v2.15.0.rc.4.3.g77725d1.dirty - Thu Mar 25 13:15:38 EDT 2021 - 77725d19f2addcb08b5a36b532cb2ef4653455f3

Do you really want to nuke the account with the ID <redacted> and the alias '<redacted>'?
Do you want to continue? Enter account alias to continue.
> <redacted>

us-east-1 - AppSyncGraphqlAPI - ux7e3d2qnbb5ri75xbjq3ajpaa - [APIID: "ux7e3d2qnbb5ri75xbjq3ajpaa", Name: "joshtest", tag:test: "val"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID <redacted> and the alias '<redacted>'?
Do you want to continue? Enter account alias to continue.
> <redacted>

us-east-1 - AppSyncGraphqlAPI - ux7e3d2qnbb5ri75xbjq3ajpaa - [APIID: "ux7e3d2qnbb5ri75xbjq3ajpaa", Name: "joshtest", tag:test: "val"] - triggered remove

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

us-east-1 - AppSyncGraphqlAPI - ux7e3d2qnbb5ri75xbjq3ajpaa - [APIID: "ux7e3d2qnbb5ri75xbjq3ajpaa", Name: "joshtest", tag:test: "val"] - waiting

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

us-east-1 - AppSyncGraphqlAPI - ux7e3d2qnbb5ri75xbjq3ajpaa - [APIID: "ux7e3d2qnbb5ri75xbjq3ajpaa", Name: "joshtest", tag:test: "val"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished

Nuke complete: 0 failed, 0 skipped, 1 finished.
```
Note: I have replaced account ids and aliases with `<redacted>` in the above.