### PR TITLE
remove armv7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       id: qemu
       uses: docker/setup-qemu-action@v1
       with:
-        platforms: arm64,arm/v7
+        platforms: arm64
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -79,4 +79,4 @@ jobs:
         context: .
         push: true
         tags: ${{ steps.generate_tags.outputs.tags }}
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The build fails for ARMv7. As we do not know why, we are going the remove the platform for now.