### PR TITLE
Fix PR builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-20.04
     name: Docker Build
+    if: "github.repository == 'rebuy-de/aws-nuke'"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This should skip the Docker build, when there are no secrets. This happens, if an external contributor opens a PR.