### PR TITLE
Add X-Ray resources

### DIFF
--- a/resources/xray-group.go
+++ b/resources/xray-group.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type XRayGroup struct {
+	svc       *xray.XRay
+	groupName *string
+	groupARN  *string
+}
+
+func init() {
+	register("XRayGroup", ListXRayGroups)
+}
+
+func ListXRayGroups(sess *session.Session) ([]Resource, error) {
+	svc := xray.New(sess)
+	resources := []Resource{}
+
+	// Get X-Ray Groups
+	var xrayGroups []*xray.GroupSummary
+	err := svc.GetGroupsPages(
+		&xray.GetGroupsInput{},
+		func(page *xray.GetGroupsOutput, lastPage bool) bool {
+			for _, group := range page.Groups {
+				if *group.GroupName != "Default" { // Ignore the Default group as it cannot be removed
+					xrayGroups = append(xrayGroups, group)
+				}
+			}
+			return true
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, group := range xrayGroups {
+		resources = append(resources, &XRayGroup{
+			svc:       svc,
+			groupName: group.GroupName,
+			groupARN:  group.GroupARN,
+		})
+	}
+
+	return resources, nil
+}
+
+func (f *XRayGroup) Remove() error {
+	_, err := f.svc.DeleteGroup(&xray.DeleteGroupInput{
+		GroupARN: f.groupARN, // Only allowed to pass GroupARN _or_ GroupName to delete request
+	})
+
+	return err
+}
+
+func (f *XRayGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("GroupName", f.groupName).
+		Set("GroupARN", f.groupARN)
+
+	return properties
+}

--- a/resources/xray-samplingrule.go
+++ b/resources/xray-samplingrule.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type XRaySamplingRule struct {
+	svc      *xray.XRay
+	ruleName *string
+	ruleARN  *string
+}
+
+func init() {
+	register("XRaySamplingRule", ListXRaySamplingRules)
+}
+
+func ListXRaySamplingRules(sess *session.Session) ([]Resource, error) {
+	svc := xray.New(sess)
+	resources := []Resource{}
+
+	var xraySamplingRules []*xray.SamplingRule
+	err := svc.GetSamplingRulesPages(
+		&xray.GetSamplingRulesInput{},
+		func(page *xray.GetSamplingRulesOutput, lastPage bool) bool {
+			for _, rule := range page.SamplingRuleRecords {
+				if *rule.SamplingRule.RuleName != "Default" {
+					xraySamplingRules = append(xraySamplingRules, rule.SamplingRule)
+				}
+			}
+			return true
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range xraySamplingRules {
+		resources = append(resources, &XRaySamplingRule{
+			svc:      svc,
+			ruleName: rule.RuleName,
+			ruleARN:  rule.RuleARN,
+		})
+	}
+
+	return resources, nil
+}
+
+func (f *XRaySamplingRule) Remove() error {
+	_, err := f.svc.DeleteSamplingRule(&xray.DeleteSamplingRuleInput{
+		RuleARN: f.ruleARN, // Specify ruleARN or ruleName, not both
+	})
+
+	return err
+}
+
+func (f *XRaySamplingRule) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("RuleName", f.ruleName).
+		Set("RuleARN", f.ruleARN)
+
+	return properties
+}


### PR DESCRIPTION
Adds support for sampling rules & groups, which are the two types of resources that are delete-able according to https://docs.aws.amazon.com/xray/latest/api/API_Operations.html 