### PR TITLE
Handle undeletable Backup Vault from EFS Automatic Backups

### DIFF
--- a/resources/backup-plans.go
+++ b/resources/backup-plans.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"strings"
 )
 
 type BackupPlan struct {
@@ -75,4 +76,11 @@ func (b *BackupPlan) Remove() error {
 
 func (b *BackupPlan) String() string {
 	return b.arn
+}
+
+func (b *BackupPlan) Filter() error {
+	if strings.HasPrefix(b.name, "aws/efs/") {
+		return fmt.Errorf("cannot delete EFS automatic backups backup plan")
+	}
+	return nil
 }

--- a/resources/backup-selections.go
+++ b/resources/backup-selections.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"strings"
 )
 
 type BackupSelection struct {
@@ -74,4 +75,11 @@ func (b *BackupSelection) Remove() error {
 
 func (b *BackupSelection) String() string {
 	return fmt.Sprintf("%s (%s)", b.planId, b.selectionId)
+}
+
+func (b *BackupSelection) Filter() error {
+	if strings.HasPrefix(b.selectionName, "aws/efs/") {
+		return fmt.Errorf("cannot delete EFS automatic backups backup selection")
+	}
+	return nil
 }

--- a/resources/backup-vaults-access-policies.go
+++ b/resources/backup-vaults-access-policies.go
@@ -1,0 +1,120 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/backup"
+)
+
+type BackupVaultAccessPolicy struct {
+	svc             *backup.Backup
+	backupVaultName string
+}
+
+func init() {
+	register("AWSBackupVaultAccessPolicy", ListBackupVaultAccessPolicies)
+}
+
+func ListBackupVaultAccessPolicies(sess *session.Session) ([]Resource, error) {
+	svc := backup.New(sess)
+	maxVaultsLen := int64(100)
+	params := &backup.ListBackupVaultsInput{
+		MaxResults: &maxVaultsLen, // aws default limit on number of backup vaults per account
+	}
+	resp, err := svc.ListBackupVaults(params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over backup vaults and add vault policies that exist.
+	resources := make([]Resource, 0)
+	for _, out := range resp.BackupVaultList {
+		// Check if the Backup Vault has an Access Policy set
+		resp, err := svc.GetBackupVaultAccessPolicy(&backup.GetBackupVaultAccessPolicyInput{
+			BackupVaultName: out.BackupVaultName,
+		})
+
+		// Non-existent Access Policies can come from ResourceNotFoundException or
+		// being nil.
+		if err != nil {
+			switch err.(type) {
+			case *backup.ResourceNotFoundException:
+				// Non-existent is OK and we skip over them
+				continue
+			default:
+				return nil, err
+			}
+		}
+
+		// Only delete policies that exist.
+		if resp.Policy != nil {
+			resources = append(resources, &BackupVaultAccessPolicy{
+				svc:             svc,
+				backupVaultName: *out.BackupVaultName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (b *BackupVaultAccessPolicy) Remove() error {
+	// Set the policy to a policy that allows deletion before removal.
+	//
+	// This is required to delete the policy for the automagically created vaults
+	// such as "aws/efs/automatic-backup-vault" from EFS automatic backups
+	// which by default Deny policy deletion via backup::DeleteBackupVaultAccessPolicy
+	//
+	// Example "aws/efs/automatic-backup-vault" default policy:
+	//
+	// {
+	//     "Version": "2012-10-17",
+	//     "Statement": [
+	//         {
+	//             "Effect": "Deny",
+	//             "Principal": {
+	//                 "AWS": "*"
+	//             },
+	//             "Action": [
+	//                 "backup:DeleteBackupVault",
+	//                 "backup:DeleteBackupVaultAccessPolicy",
+	//                 "backup:DeleteRecoveryPoint",
+	//                 "backup:StartCopyJob",
+	//                 "backup:StartRestoreJob",
+	//                 "backup:UpdateRecoveryPointLifecycle"
+	//             ],
+	//             "Resource": "*"
+	//         }
+	//     ]
+	// }
+	//
+	// While deletion is Denied, you can update the policy with one that
+	// doesn't deny and then delete at will.
+	allowDeletionPolicy := `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "backup:DeleteBackupVaultAccessPolicy",
+            "Resource": "*"
+        }
+    ]
+}`
+	_, err := b.svc.PutBackupVaultAccessPolicy(&backup.PutBackupVaultAccessPolicyInput{
+		BackupVaultName: &b.backupVaultName,
+		Policy:          &allowDeletionPolicy,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = b.svc.DeleteBackupVaultAccessPolicy(&backup.DeleteBackupVaultAccessPolicyInput{
+		BackupVaultName: &b.backupVaultName,
+	})
+	return err
+}
+
+func (b *BackupVaultAccessPolicy) String() string {
+	return b.backupVaultName
+}

--- a/resources/backup-vaults-access-policies.go
+++ b/resources/backup-vaults-access-policies.go
@@ -102,14 +102,13 @@ func (b *BackupVaultAccessPolicy) Remove() error {
         }
     ]
 }`
-	_, err := b.svc.PutBackupVaultAccessPolicy(&backup.PutBackupVaultAccessPolicyInput{
+	// Ignore error from if we can't put permissive backup vault policy in for some reason, that's OK.
+	_, _ = b.svc.PutBackupVaultAccessPolicy(&backup.PutBackupVaultAccessPolicyInput{
 		BackupVaultName: &b.backupVaultName,
 		Policy:          &allowDeletionPolicy,
 	})
-	if err != nil {
-		return err
-	}
-	_, err = b.svc.DeleteBackupVaultAccessPolicy(&backup.DeleteBackupVaultAccessPolicyInput{
+	// In the end, this is the only call we actually really care about for err.
+	_, err := b.svc.DeleteBackupVaultAccessPolicy(&backup.DeleteBackupVaultAccessPolicyInput{
 		BackupVaultName: &b.backupVaultName,
 	})
 	return err

--- a/resources/backup-vaults.go
+++ b/resources/backup-vaults.go
@@ -62,3 +62,10 @@ func (b *BackupVault) Remove() error {
 func (b *BackupVault) String() string {
 	return b.arn
 }
+
+func (b *BackupVault) Filter() error {
+	if b.name == "aws/efs/automatic-backup-vault" {
+		return fmt.Errorf("cannot delete EFS automatic backups vault")
+	}
+	return nil
+}


### PR DESCRIPTION
Closes https://github.com/rebuy-de/aws-nuke/issues/599

That issue discusses the EFS Automatic Backup Vault and associated resources that cannot be deleted even by the root user. 

These changes try to filter these undeletable EFS automatic backup resources and nullify/remove the default policy such as the one on the default `aws/efs/automatic-backup-vault` that disallow deletion of the policy and recovery points. As a result, the changes make aws-nuke no longer error out and also able to clear out the EFS Automatic Backup Vault.

A test environment can be recreated by:

1. Creating an EFS File system from the AWS Management Console

That's it. [AWS turned on "Automatic Backups" for all new EFS filesystems and there is no option from the console to opt-out during creation since Jul 17, 2020.](https://aws.amazon.com/about-aws/whats-new/2020/07/announcing-automatic-backups-for-amazon-elastic-file-system/) You can turn it off afterwards, but the undeletable Backup Vault and associated resources will have been created.