### PR TITLE
Enable us-gov-cloud by setting the default partition correctly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/rebuy-de/aws-nuke/pkg/awsutil"
 	"github.com/rebuy-de/aws-nuke/pkg/config"
 	"github.com/rebuy-de/aws-nuke/resources"
@@ -63,10 +64,17 @@ func NewRootCommand() *cobra.Command {
 
 		if defaultRegion != "" {
 			awsutil.DefaultRegionID = defaultRegion
-			if config.CustomEndpoints.GetRegion(defaultRegion) == nil {
-				err = fmt.Errorf("The custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)
-				log.Error(err.Error())
-				return err
+			switch defaultRegion {
+			case endpoints.UsEast1RegionID, endpoints.UsEast2RegionID, endpoints.UsWest1RegionID, endpoints.UsWest2RegionID:
+				awsutil.DefaultAWSPartitionID = endpoints.AwsPartitionID
+			case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
+				awsutil.DefaultAWSPartitionID = endpoints.AwsUsGovPartitionID
+			default:
+				if config.CustomEndpoints.GetRegion(defaultRegion) == nil {
+					err = fmt.Errorf("The custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)
+					log.Error(err.Error())
+					return err
+				}
 			}
 		}
 

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -24,6 +24,9 @@ const (
 var (
 	// DefaultRegionID The default region. Can be customized for non AWS implementations
 	DefaultRegionID = endpoints.UsEast1RegionID
+
+	// DefaultAWSPartitionID The default aws partition. Can be customized for non AWS implementations
+	DefaultAWSPartitionID = endpoints.AwsPartitionID
 )
 
 type Credentials struct {
@@ -193,7 +196,7 @@ func skipMissingServiceInRegionHandler(r *request.Request) {
 	region := *r.Config.Region
 	service := r.ClientInfo.ServiceName
 
-	rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, service)
+	rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), DefaultAWSPartitionID, service)
 	if !ok {
 		// This means that the service does not exist and this shouldn't be handled here.
 		return
@@ -216,7 +219,7 @@ func skipGlobalHandler(global bool) func(r *request.Request) {
 	return func(r *request.Request) {
 		service := r.ClientInfo.ServiceName
 
-		rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, service)
+		rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), DefaultAWSPartitionID, service)
 		if !ok {
 			// This means that the service does not exist in the endpoints list.
 			if global {


### PR DESCRIPTION
This addresses https://github.com/rebuy-de/aws-nuke/issues/440

The approach here is to allow folks to set the flag `--default-region`. If it is a known AWS region the correct partition is used. If it is not a known AWS region then the user is required to add endpoints into the config, which was the original default behavior. The idea is for this to augment but not replace or modify any existing functionality.

The constants being used can be found in the documentation here: https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/#pkg-constants. More configuration can be done for other regions and partitions but I leave that to others to implement.