### PR TITLE
Only build docker images on our own PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-20.04
     name: Docker Build
-    if: "github.repository == 'rebuy-de/aws-nuke'"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'rebuy-de/aws-nuke' }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
"Foreign" PR builds always failed because they have no permissions to read our Docker Hub / Quay secrets. This is a quick fix to skip the Docker build on PRs where the head is not from this repository.
See #658 for the PoC.