### PR TITLE
Add tags to IAM resources

### DIFF
--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -38,7 +38,12 @@ func ListIAMPolicies(sess *session.Session) ([]Resource, error) {
 
 	err := svc.ListPoliciesPages(params,
 		func(page *iam.ListPoliciesOutput, lastPage bool) bool {
-			for _, policy := range page.Policies {
+			for _, listedPolicy := range page.Policies {
+				policy, err := GetIAMPolicy(svc, listedPolicy.Arn)
+				if err != nil {
+					logrus.Errorf("Failed to get listed policy %s: %v", *listedPolicy.PolicyName, err)
+					break
+				}
 				policies = append(policies, policy)
 			}
 			return true

--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -19,6 +19,14 @@ func init() {
 	register("IAMPolicy", ListIAMPolicies)
 }
 
+func GetIAMPolicy(svc *iam.IAM, policyArn *string) (*iam.Policy, error) {
+	params := &iam.GetPolicyInput{
+		PolicyArn: policyArn,
+	}
+	resp, err := svc.GetPolicy(params)
+	return resp.Policy, err
+}
+
 func ListIAMPolicies(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
 

--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -13,6 +14,7 @@ type IAMPolicy struct {
 	policyId string
 	arn      string
 	path     string
+	tags     []*iam.Tag
 }
 
 func init() {
@@ -61,6 +63,7 @@ func ListIAMPolicies(sess *session.Session) ([]Resource, error) {
 			path:     *out.Path,
 			arn:      *out.Arn,
 			policyId: *out.PolicyId,
+			tags:     out.Tags,
 		})
 	}
 
@@ -103,6 +106,9 @@ func (policy *IAMPolicy) Properties() types.Properties {
 	properties.Set("ARN", policy.arn)
 	properties.Set("Path", policy.path)
 	properties.Set("PolicyID", policy.policyId)
+	for _, tag := range policy.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
 	return properties
 }
 

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -32,7 +32,13 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 			return nil, err
 		}
 
-		for _, role := range roleResp.Roles {
+		for _, listedRole := range roleResp.Roles {
+			role, err := GetIAMRole(svc, listedRole.RoleName)
+			if err != nil {
+				logrus.Errorf("Failed to get listed role %s: %v", *listedRole.RoleName, err)
+				continue
+			}
+
 			polParams := &iam.ListAttachedRolePoliciesInput{
 				RoleName: role.RoleName,
 			}

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -15,6 +15,7 @@ type IAMRolePolicyAttachment struct {
 	policyArn  string
 	policyName string
 	roleName   string
+	roleTags   []*iam.Tag
 }
 
 func init() {
@@ -56,6 +57,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 						policyArn:  *pol.PolicyArn,
 						policyName: *pol.PolicyName,
 						roleName:   *role.RoleName,
+						roleTags:   role.Tags,
 					})
 				}
 
@@ -98,10 +100,14 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 }
 
 func (e *IAMRolePolicyAttachment) Properties() types.Properties {
-	return types.NewProperties().
+	properties := types.NewProperties().
 		Set("RoleName", e.roleName).
 		Set("PolicyName", e.policyName).
 		Set("PolicyArn", e.policyArn)
+	for _, tag := range e.roleTags {
+		properties.SetTagWithPrefix("role", tag.Key, tag.Value)
+	}
+	return properties
 }
 
 func (e *IAMRolePolicyAttachment) String() string {

--- a/resources/iam-role-policy.go
+++ b/resources/iam-role-policy.go
@@ -32,7 +32,13 @@ func ListIAMRolePolicies(sess *session.Session) ([]Resource, error) {
 			return nil, err
 		}
 
-		for _, role := range roles.Roles {
+		for _, listedRole := range roles.Roles {
+			role, err := GetIAMRole(svc, listedRole.RoleName)
+			if err != nil {
+				logrus.Errorf("Failed to get listed role %s: %v", *listedRole.RoleName, err)
+				continue
+			}
+
 			polParams := &iam.ListRolePoliciesInput{
 				RoleName: role.RoleName,
 			}

--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -21,6 +21,14 @@ func init() {
 	register("IAMRole", ListIAMRoles)
 }
 
+func GetIAMRole(svc *iam.IAM, roleName *string) (*iam.Role, error) {
+	params := &iam.GetRoleInput{
+		RoleName: roleName,
+	}
+	resp, err := svc.GetRole(params)
+	return resp.Role, err
+}
+
 func ListIAMRoles(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
 	params := &iam.ListRolesInput{}
@@ -33,10 +41,7 @@ func ListIAMRoles(sess *session.Session) ([]Resource, error) {
 		}
 
 		for _, out := range resp.Roles {
-			getroleParams := &iam.GetRoleInput{
-				RoleName: out.RoleName,
-			}
-			getroleOutput, err := svc.GetRole(getroleParams)
+			role, err := GetIAMRole(svc, out.RoleName)
 			if err != nil {
 				logrus.
 					WithError(err).
@@ -47,9 +52,9 @@ func ListIAMRoles(sess *session.Session) ([]Resource, error) {
 
 			resources = append(resources, &IAMRole{
 				svc:  svc,
-				role: getroleOutput.Role,
-				name: *getroleOutput.Role.RoleName,
-				path: *getroleOutput.Role.Path,
+				role: role,
+				name: *role.RoleName,
+				path: *role.Path,
 			})
 		}
 


### PR DESCRIPTION
Working on a use-case that requires us to filter IAM Policies by tags, which is not yet possible in aws-nuke.

This turned into a bigger change than originally expected. The reason is, the IAM `List*` APIs are not returning tags. The `Get*` APIs are, however. This was not obvious at first because the responses of the List and Get APIs are of the same _type_, which includes a `Tags` property. But alas, after testing I confirmed that the only the Gets in fact return them.

### The goal
A few improvements to the IAM resource filtering capabilities:
1. filter IAM policies by their tags
2. filter IAM role policies (inline policies) by their role's tags
   - _technically this was already implemented but it was broken because the code assumed the `List*` API returned the Tags (see above)_
3. filter IAM role policy attachments (managed policies) by their role's tags

### The solution

Needed to create two new shared functions: `GetIAMPolicy` and `GetIAMRole` to actually perform the `Get*` API call. I put these in `iam-roles.go` and `iam-policies.go` respectively, but I'm open to a more common location like a util.

After listing each of the mentioned resources, immediately make a Get call to grab the entire resource. Then, use extract properties from that instead of the object returned in the List API. 