### PR TITLE
[WIP] Add tags to IAM Role Policy Attachment resource

### DIFF
--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -15,7 +15,7 @@ type IAMRolePolicyAttachment struct {
 	policyArn  string
 	policyName string
 	roleName   string
-	roleTags   []*iam.Tag
+	roleTags   []iam.Tag
 }
 
 func init() {

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -51,7 +51,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 						policyArn:  *pol.PolicyArn,
 						policyName: *pol.PolicyName,
 						roleName:   *role.RoleName,
-						roleTags:   *role.Tags
+						roleTags:   *role.Tags,
 					})
 				}
 

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -15,7 +15,7 @@ type IAMRolePolicyAttachment struct {
 	policyArn  string
 	policyName string
 	roleName   string
-	roleTags   []iam.Tag
+	roleTags   []*iam.Tag
 }
 
 func init() {
@@ -51,7 +51,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 						policyArn:  *pol.PolicyArn,
 						policyName: *pol.PolicyName,
 						roleName:   *role.RoleName,
-						roleTags:   *role.Tags,
+						roleTags:   role.Tags,
 					})
 				}
 

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -15,6 +15,7 @@ type IAMRolePolicyAttachment struct {
 	policyArn  string
 	policyName string
 	roleName   string
+	roleTags   []*iam.Tag
 }
 
 func init() {
@@ -50,6 +51,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 						policyArn:  *pol.PolicyArn,
 						policyName: *pol.PolicyName,
 						roleName:   *role.RoleName,
+						roleTags:   *role.Tags
 					})
 				}
 
@@ -92,10 +94,14 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 }
 
 func (e *IAMRolePolicyAttachment) Properties() types.Properties {
-	return types.NewProperties().
+	properties := types.NewProperties().
 		Set("RoleName", e.roleName).
 		Set("PolicyName", e.policyName).
 		Set("PolicyArn", e.policyArn)
+	for _, tag := range e.roleTags {
+		properties.SetTagWithPrefix("roleTag", tag.Key, tag.Value)
+	}
+	return properties
 }
 
 func (e *IAMRolePolicyAttachment) String() string {


### PR DESCRIPTION
We're working on a use-case that requires us to filter IAM resources by their tags.

IAM roles are already filterable by tags
IAM policies will be filterable by tags starting with #662 

However, if we don't delete the role or the policy, then we should also not remove the attachment. There is currently no way to filter out attachments based on the role they are attached to.

This PR adds a new field to the resource's properties, `roleTag`, which you can filter on.

### A note about the tag property name
Since the attachment itself does not have any tags, I decided to use the tags from the role. To be more reflective of the actual resource, and to prevent confusion, I went with `roleTag` instead of `tag`. This means that in order to filter out an `IAMRolePolicyAttachment` by tag, you would need to do something like this instead (just use "roleTag"):
```
IAMRolePolicyAttachment:
  - property: "roleTag:SomeTagKey"
    value: "SomeTagValue"
```

Somebody could probably also convince me to add in the policy tags too...