### PR TITLE
Add ability to assume a role before nuking

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,6 +118,11 @@ func NewRootCommand() *cobra.Command {
 			"Must be used together with --access-key-id and --secret-access-key. "+
 			"Cannot be used together with --profile.")
 	command.PersistentFlags().StringVar(
+		&creds.AssumeRoleArn, "assume-role-arn", "",
+		"AWS IAM role arn to assume. "+
+		    "The credentials provided via --access-key-id or --profile must "+
+			"be allowed to assume this role. ")
+	command.PersistentFlags().StringVar(
 		&defaultRegion, "default-region", "",
 		"Custom default region name.")
 

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -111,6 +111,11 @@ func (c *Credentials) rootSession() (*session.Session, error) {
 			return nil, err
 		}
 
+		// if given a role to assume, overwrite the session credentials with assume role credentials
+		if c.AssumeRoleArn != "" {
+			sess.Config.Credentials = stscreds.NewCredentials(sess, c.AssumeRoleArn)
+		}
+
 		c.session = sess
 	}
 

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -35,6 +35,7 @@ type Credentials struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
+	AssumeRoleArn   string
 
 	Credentials *credentials.Credentials
 


### PR DESCRIPTION
We're hitting a similar `ExpiredTokenException` error as this issue: https://github.com/rebuy-de/aws-nuke/issues/396

According to docs, if you use the `stscreds` package to assume a role, it will [attempt to refresh every 15 minutes](https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.38.42/aws/credentials/stscreds#NewCredentials). So, this PR adds the ability to pass an `--assume-role-arn` flag and assume that role before initializing any AWS clients.

Coincidentally, I think this PR also addresses https://github.com/rebuy-de/aws-nuke/issues/409

### Testing

I put a `sess.Config.Credentials.Expire()` before initializing the SNS client here: https://github.com/rebuy-de/aws-nuke/blob/7f44b330b9bc9bcae297de728a896323e118d954/resources/sns-topics.go#L22

The client was expired before the `ListTopicsPages` call, but once that call was complete, the credentials were no longer expired (check for expired status with `Credentials.IsExpired()`)

```
Do you really want to nuke the account with the ID 123456789012 and the alias 'my-account'?
Waiting 3s before continuing.

IS EXPIRED, before expiry%!(EXTRA bool=false)
IS EXPIRED, after expiry%!(EXTRA bool=true)
IS EXPIRED, after initialization%!(EXTRA bool=true)
IS EXPIRED, after GET%!(EXTRA bool=false)
us-east-1 - SNSTopic - TopicARN: arn:aws:sns:us-east-1:123456789012:TestTopic - [TopicARN: "arn:aws:sns:us-east-1:123456789012:TestTopic"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.
```
