### PR TITLE
Add important EC2 metadata to instance properties

### DIFF
--- a/resources/ec2-instances.go
+++ b/resources/ec2-instances.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -108,9 +109,16 @@ func (i *EC2Instance) DisableProtection() error {
 
 func (i *EC2Instance) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("Identifier", i.instance.InstanceId)
+	properties.Set("ImageIdentifier", i.instance.ImageId)
+	properties.Set("InstanceState", i.instance.State.Name)
+	properties.Set("InstanceType", i.instance.InstanceType)
+	properties.Set("LaunchTime", i.instance.LaunchTime.Format(time.RFC3339))
+
 	for _, tagValue := range i.instance.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
+
 	return properties
 }
 


### PR DESCRIPTION
In order to power filtering of EC2 instances via common properties, this commit adds instance identifier, image identifier, instance state, instance type, and instance launch time to the properties for EC2 resources.

This allows (for example):
- pruning instances launched from a specific AMI.
- pruning instances launched a given duration ago.
- pruning instances that are stopped.
- pruning instances of a given type.

This PR closes rebuy-de/aws-nuke#640.