### PR TITLE
Add ability to nuke all enabled regions in an account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ regions:
 - eu-west-1
 - global
 
+# Instead of explicitly listing regions, you can also enable this option.
+use-enabled-regions: false
+
 account-blocklist:
 - "999999999999" # production
 

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -153,7 +153,19 @@ func (n *Nuke) Scan() error {
 
 	queue := make(Queue, 0)
 
-	for _, regionName := range n.Config.Regions {
+	var regions []string
+	if n.Config.UseEnabledRegions {
+		regions = n.Account.EnabledRegions()
+		fmt.Printf("The 'use-enabled-regions' configuration flag is enabled, ignoring explicit region configuration.\n")
+		fmt.Printf("Nuking the following regions:\n")
+		for _, region := range regions {
+			fmt.Printf("  - %s\n", region)
+		}
+	} else {
+		regions = n.Config.Regions
+	}
+
+	for _, regionName := range regions {
 		region := NewRegion(regionName, n.Account.ResourceTypeToServiceType, n.Account.NewSession)
 
 		items := Scan(region, resourceTypes)
@@ -184,7 +196,6 @@ func (n *Nuke) Scan() error {
 }
 
 func (n *Nuke) Filter(item *Item) error {
-
 	checker, ok := item.Resource.(resources.Filter)
 	if ok {
 		err := checker.Filter()
@@ -251,7 +262,6 @@ func (n *Nuke) HandleQueue() {
 			n.HandleWait(item, listCache)
 			item.Print()
 		}
-
 	}
 
 	fmt.Println()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,14 +24,15 @@ type Account struct {
 
 type Nuke struct {
 	// Deprecated: Use AccountBlocklist instead.
-	AccountBlacklist []string                     `yaml:"account-blacklist"`
-	AccountBlocklist []string                     `yaml:"account-blocklist"`
-	Regions          []string                     `yaml:"regions"`
-	Accounts         map[string]Account           `yaml:"accounts"`
-	ResourceTypes    ResourceTypes                `yaml:"resource-types"`
-	Presets          map[string]PresetDefinitions `yaml:"presets"`
-	FeatureFlags     FeatureFlags                 `yaml:"feature-flags"`
-	CustomEndpoints  CustomEndpoints              `yaml:"endpoints"`
+	AccountBlacklist  []string                     `yaml:"account-blacklist"`
+	AccountBlocklist  []string                     `yaml:"account-blocklist"`
+	Regions           []string                     `yaml:"regions"`
+	UseEnabledRegions bool                         `yaml:"use-enabled-regions"`
+	Accounts          map[string]Account           `yaml:"accounts"`
+	ResourceTypes     ResourceTypes                `yaml:"resource-types"`
+	Presets           map[string]PresetDefinitions `yaml:"presets"`
+	FeatureFlags      FeatureFlags                 `yaml:"feature-flags"`
+	CustomEndpoints   CustomEndpoints              `yaml:"endpoints"`
 }
 
 type FeatureFlags struct {


### PR DESCRIPTION
This is an initial attempt at addressing https://github.com/rebuy-de/aws-nuke/issues/375.

Appreciate any feedback you can provide! I'm not sure about the "UX" side of things, because this is effectively making aws-nuke even more destructive :)

This commit introduces a new configuration key `use-enabled-regions`. When enabled aws-nuke will list all "enabled"
regions using ec2.DescribeRegions.