### PR TITLE
advertise association with default vpc through properties

### DIFF
--- a/resources/ec2-internet-gateway-attachments.go
+++ b/resources/ec2-internet-gateway-attachments.go
@@ -10,12 +10,12 @@ import (
 )
 
 type EC2InternetGatewayAttachment struct {
-	svc         *ec2.EC2
-	vpcId       *string
-	vpcTags     []*ec2.Tag
-	igwId       *string
-	igwTags     []*ec2.Tag
-	defVpcAssoc bool
+	svc        *ec2.EC2
+	vpcId      *string
+	vpcTags    []*ec2.Tag
+	igwId      *string
+	igwTags    []*ec2.Tag
+	defaultVPC bool
 }
 
 func init() {
@@ -48,12 +48,12 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 
 		for _, igw := range resp.InternetGateways {
 			resources = append(resources, &EC2InternetGatewayAttachment{
-				svc:         svc,
-				vpcId:       vpc.VpcId,
-				vpcTags:     vpc.Tags,
-				igwId:       igw.InternetGatewayId,
-				igwTags:     igw.Tags,
-				defVpcAssoc: *vpc.IsDefault,
+				svc:        svc,
+				vpcId:      vpc.VpcId,
+				vpcTags:    vpc.Tags,
+				igwId:      igw.InternetGatewayId,
+				igwTags:    igw.Tags,
+				defaultVPC: *vpc.IsDefault,
 			})
 		}
 	}
@@ -83,7 +83,7 @@ func (e *EC2InternetGatewayAttachment) Properties() types.Properties {
 	for _, tagValue := range e.vpcTags {
 		properties.SetTagWithPrefix("vpc", tagValue.Key, tagValue.Value)
 	}
-	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
+	properties.Set("DefaultVPC", e.defaultVPC)
 	return properties
 }
 

--- a/resources/ec2-internet-gateway-attachments.go
+++ b/resources/ec2-internet-gateway-attachments.go
@@ -10,11 +10,12 @@ import (
 )
 
 type EC2InternetGatewayAttachment struct {
-	svc     *ec2.EC2
-	vpcId   *string
-	vpcTags []*ec2.Tag
-	igwId   *string
-	igwTags []*ec2.Tag
+	svc         *ec2.EC2
+	vpcId       *string
+	vpcTags     []*ec2.Tag
+	igwId       *string
+	igwTags     []*ec2.Tag
+	defVpcAssoc bool
 }
 
 func init() {
@@ -47,11 +48,12 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 
 		for _, igw := range resp.InternetGateways {
 			resources = append(resources, &EC2InternetGatewayAttachment{
-				svc:     svc,
-				vpcId:   vpc.VpcId,
-				vpcTags: vpc.Tags,
-				igwId:   igw.InternetGatewayId,
-				igwTags: igw.Tags,
+				svc:         svc,
+				vpcId:       vpc.VpcId,
+				vpcTags:     vpc.Tags,
+				igwId:       igw.InternetGatewayId,
+				igwTags:     igw.Tags,
+				defVpcAssoc: *vpc.IsDefault,
 			})
 		}
 	}
@@ -81,6 +83,7 @@ func (e *EC2InternetGatewayAttachment) Properties() types.Properties {
 	for _, tagValue := range e.vpcTags {
 		properties.SetTagWithPrefix("vpc", tagValue.Key, tagValue.Value)
 	}
+	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
 	return properties
 }
 

--- a/resources/ec2-internet-gateways.go
+++ b/resources/ec2-internet-gateways.go
@@ -7,9 +7,9 @@ import (
 )
 
 type EC2InternetGateway struct {
-	svc         *ec2.EC2
-	igw         *ec2.InternetGateway
-	defVpcAssoc bool
+	svc        *ec2.EC2
+	igw        *ec2.InternetGateway
+	defaultVPC bool
 }
 
 func init() {
@@ -29,9 +29,9 @@ func ListEC2InternetGateways(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, igw := range resp.InternetGateways {
 		resources = append(resources, &EC2InternetGateway{
-			svc:         svc,
-			igw:         igw,
-			defVpcAssoc: HasVpcAttachment(defVpcId, igw.Attachments),
+			svc:        svc,
+			igw:        igw,
+			defaultVPC: HasVpcAttachment(defVpcId, igw.Attachments),
 		})
 	}
 
@@ -69,7 +69,7 @@ func (e *EC2InternetGateway) Properties() types.Properties {
 	for _, tagValue := range e.igw.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
-	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
+	properties.Set("DefaultVPC", e.defaultVPC)
 	return properties
 }
 

--- a/resources/ec2-internet-gateways.go
+++ b/resources/ec2-internet-gateways.go
@@ -7,8 +7,9 @@ import (
 )
 
 type EC2InternetGateway struct {
-	svc *ec2.EC2
-	igw *ec2.InternetGateway
+	svc         *ec2.EC2
+	igw         *ec2.InternetGateway
+	defVpcAssoc bool
 }
 
 func init() {
@@ -23,15 +24,31 @@ func ListEC2InternetGateways(sess *session.Session) ([]Resource, error) {
 		return nil, err
 	}
 
+	defVpcId := DefaultVpcID(svc)
+
 	resources := make([]Resource, 0)
 	for _, igw := range resp.InternetGateways {
 		resources = append(resources, &EC2InternetGateway{
-			svc: svc,
-			igw: igw,
+			svc:         svc,
+			igw:         igw,
+			defVpcAssoc: HasVpcAttachment(defVpcId, igw.Attachments),
 		})
 	}
 
 	return resources, nil
+}
+
+func HasVpcAttachment(vpcId *string, attachments []*ec2.InternetGatewayAttachment) bool {
+	if vpcId == nil {
+		return false
+	}
+
+	for _, attach := range attachments {
+		if *vpcId == *attach.VpcId {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *EC2InternetGateway) Remove() error {
@@ -52,6 +69,7 @@ func (e *EC2InternetGateway) Properties() types.Properties {
 	for _, tagValue := range e.igw.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
+	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
 	return properties
 }
 

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -7,9 +7,9 @@ import (
 )
 
 type EC2RouteTable struct {
-	svc         *ec2.EC2
-	routeTable  *ec2.RouteTable
-	defVpcAssoc bool
+	svc        *ec2.EC2
+	routeTable *ec2.RouteTable
+	defaultVPC bool
 }
 
 func init() {
@@ -29,9 +29,9 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, out := range resp.RouteTables {
 		resources = append(resources, &EC2RouteTable{
-			svc:         svc,
-			routeTable:  out,
-			defVpcAssoc: *defVpcId == *out.VpcId,
+			svc:        svc,
+			routeTable: out,
+			defaultVPC: *defVpcId == *out.VpcId,
 		})
 	}
 
@@ -56,7 +56,7 @@ func (e *EC2RouteTable) Properties() types.Properties {
 	for _, tagValue := range e.routeTable.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
-	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
+	properties.Set("DefaultVPC", e.defaultVPC)
 	return properties
 }
 

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -7,8 +7,9 @@ import (
 )
 
 type EC2RouteTable struct {
-	svc        *ec2.EC2
-	routeTable *ec2.RouteTable
+	svc         *ec2.EC2
+	routeTable  *ec2.RouteTable
+	defVpcAssoc bool
 }
 
 func init() {
@@ -23,11 +24,14 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 		return nil, err
 	}
 
+	defVpcId := DefaultVpcID(svc)
+
 	resources := make([]Resource, 0)
 	for _, out := range resp.RouteTables {
 		resources = append(resources, &EC2RouteTable{
-			svc:        svc,
-			routeTable: out,
+			svc:         svc,
+			routeTable:  out,
+			defVpcAssoc: *defVpcId == *out.VpcId,
 		})
 	}
 
@@ -52,6 +56,7 @@ func (e *EC2RouteTable) Properties() types.Properties {
 	for _, tagValue := range e.routeTable.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
+	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
 	return properties
 }
 

--- a/resources/ec2-subnets.go
+++ b/resources/ec2-subnets.go
@@ -7,8 +7,9 @@ import (
 )
 
 type EC2Subnet struct {
-	svc    *ec2.EC2
-	subnet *ec2.Subnet
+	svc         *ec2.EC2
+	subnet      *ec2.Subnet
+	defVpcAssoc bool
 }
 
 func init() {
@@ -24,11 +25,14 @@ func ListEC2Subnets(sess *session.Session) ([]Resource, error) {
 		return nil, err
 	}
 
+	defVpcId := DefaultVpcID(svc)
+
 	resources := make([]Resource, 0)
 	for _, out := range resp.Subnets {
 		resources = append(resources, &EC2Subnet{
-			svc:    svc,
-			subnet: out,
+			svc:         svc,
+			subnet:      out,
+			defVpcAssoc: *defVpcId == *out.VpcId,
 		})
 	}
 
@@ -54,6 +58,7 @@ func (e *EC2Subnet) Properties() types.Properties {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.Set("DefaultForAz", e.subnet.DefaultForAz)
+	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
 	return properties
 }
 

--- a/resources/ec2-subnets.go
+++ b/resources/ec2-subnets.go
@@ -7,9 +7,9 @@ import (
 )
 
 type EC2Subnet struct {
-	svc         *ec2.EC2
-	subnet      *ec2.Subnet
-	defVpcAssoc bool
+	svc        *ec2.EC2
+	subnet     *ec2.Subnet
+	defaultVPC bool
 }
 
 func init() {
@@ -30,9 +30,9 @@ func ListEC2Subnets(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, out := range resp.Subnets {
 		resources = append(resources, &EC2Subnet{
-			svc:         svc,
-			subnet:      out,
-			defVpcAssoc: *defVpcId == *out.VpcId,
+			svc:        svc,
+			subnet:     out,
+			defaultVPC: *defVpcId == *out.VpcId,
 		})
 	}
 
@@ -58,7 +58,7 @@ func (e *EC2Subnet) Properties() types.Properties {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.Set("DefaultForAz", e.subnet.DefaultForAz)
-	properties.Set("DefaultVpcAssoc", e.defVpcAssoc)
+	properties.Set("DefaultVPC", e.defaultVPC)
 	return properties
 }
 

--- a/resources/ec2-vpc.go
+++ b/resources/ec2-vpc.go
@@ -1,14 +1,15 @@
 package resources
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type EC2VPC struct {
-	svc       *ec2.EC2
-	vpc       *ec2.Vpc
+	svc *ec2.EC2
+	vpc *ec2.Vpc
 }
 
 func init() {
@@ -26,12 +27,34 @@ func ListEC2VPCs(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	for _, vpc := range resp.Vpcs {
 		resources = append(resources, &EC2VPC{
-			svc:       svc,
-			vpc:       vpc,
+			svc: svc,
+			vpc: vpc,
 		})
 	}
 
 	return resources, nil
+}
+
+func DefaultVpcID(svc *ec2.EC2) *string {
+	resp, err := svc.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("is-default"),
+				Values: aws.StringSlice([]string{"true"}),
+			},
+		},
+	})
+
+	noVpc := ""
+	if err != nil {
+		return &noVpc
+	}
+
+	if len(resp.Vpcs) == 0 {
+		return &noVpc
+	}
+
+	return resp.Vpcs[0].VpcId
 }
 
 func (e *EC2VPC) Remove() error {


### PR DESCRIPTION
Make it easier to identify resources that are associated with the default VPC within an AWS account. This enables easier filtering, to preserve those resources. Resources that are of interest:

- EC2InternetGateway
- EC2InternetGatewayAttachment
- EC2RouteTable
- EC2Subnet

Association would be identified through a property called `DefaultVpcAssoc` as follows:

```text
eu-west-1 - EC2InternetGateway - igw-04e54fb4f65ad00be - [DefaultVpcAssoc: "false", tag:Name: "sandbox"] - would remove
eu-west-1 - EC2InternetGateway - igw-cda705ab - [DefaultVpcAssoc: "true"] - would remove
eu-west-1 - EC2RouteTable - rtb-0c54296cacbbc7541 - [DefaultVpcAssoc: "false", tag:Name: "public"] - would remove
eu-west-1 - EC2RouteTable - rtb-0d4dab8b11e4b3f1b - [DefaultVpcAssoc: "false", tag:Name: "private"] - would remove
eu-west-1 - EC2RouteTable - rtb-e021f998 - [DefaultVpcAssoc: "true"] - would remove
eu-west-1 - EC2Subnet - subnet-06b50835fc6073208 - [DefaultForAz: "false", DefaultVpcAssoc: "false", tag:Name: "Private"] - would remove
eu-west-1 - EC2Subnet - subnet-3136c47a - [DefaultForAz: "true", DefaultVpcAssoc: "true"] - filtered by config
eu-west-1 - EC2Subnet - subnet-efe5c9b5 - [DefaultForAz: "true", DefaultVpcAssoc: "true"] - filtered by config
eu-west-1 - EC2Subnet - subnet-0a6a70b0ead5efe9b - [DefaultForAz: "false", DefaultVpcAssoc: "false", tag:Name: "Public"] - would remove
eu-west-1 - EC2Subnet - subnet-634ba81a - [DefaultForAz: "true", DefaultVpcAssoc: "true"] - filtered by config
eu-west-1 - EC2InternetGatewayAttachment - igw-04e54fb4f65ad00be -> vpc-0bb7ed4a1758f6ab6 - [DefaultVpcAssoc: "false", tag:igw:Name: "sandbox", tag:vpc:Creator: "*********", tag:vpc:Name: "sandbox-vpc"] - would remove
eu-west-1 - EC2InternetGatewayAttachment - igw-cda705ab -> vpc-18de6f61 - [DefaultVpcAssoc: "true"] - would remove
```

Fixes #690 