### PR TITLE
Ignore failed entities and sentiments jobs

### DIFF
--- a/resources/comprehend_entities_detection_job.go
+++ b/resources/comprehend_entities_detection_job.go
@@ -22,7 +22,8 @@ func ListComprehendEntitiesDetectionJobs(sess *session.Session) ([]Resource, err
 			return nil, err
 		}
 		for _, entitiesDetectionJob := range resp.EntitiesDetectionJobPropertiesList {
-			if *entitiesDetectionJob.JobStatus == "STOPPED" {
+			if *entitiesDetectionJob.JobStatus == "STOPPED" ||
+				*entitiesDetectionJob.JobStatus == "FAILED" {
 				// if the job has already been stopped, do not try to delete it again
 				continue
 			}

--- a/resources/comprehend_sentiment_detection_job.go
+++ b/resources/comprehend_sentiment_detection_job.go
@@ -22,6 +22,11 @@ func ListComprehendSentimentDetectionJobs(sess *session.Session) ([]Resource, er
 			return nil, err
 		}
 		for _, sentimentDetectionJob := range resp.SentimentDetectionJobPropertiesList {
+			if *sentimentDetectionJob.JobStatus == "STOPPED" ||
+				*sentimentDetectionJob.JobStatus == "FAILED" {
+				// if the job has already been stopped, do not try to delete it again
+				continue
+			}
 			resources = append(resources, &ComprehendSentimentDetectionJob{
 				svc:                   svc,
 				sentimentDetectionJob: sentimentDetectionJob,


### PR DESCRIPTION
Failed comprehend jobs cannot currently be deleted. If not ignored aws-nuke will re-run several times before declaring it's failed to remove them.