### PR TITLE
Logging tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /dist
 /releases
 /mocks
+.envrc
+config.yaml


### PR DESCRIPTION
This adds an improvement around logging so that all logrus levels are supported and so that the log level can be changed from info to warn or error as an example.

`--verbose` is still there and will work, but logs a warn deprecated message informing the user they should use `--log-level=debug` instead.

The new option is `--log-level` and supports `trace,debug,info,warn,error`.

Why this change? Now you can set `--log-level=error` and make the output in conjunction with --quiet only log the resources and errors it encounters along the way.

Also adding `config.yaml` and `.envrc` to the .gitignore so for those doing development work `config.yaml` is automatically excluded and `.envrc` for [direnv](https://direnv.net) users such as myself.