### PR TITLE
GoReleaser Support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/amd64"
   - use: buildx
     goos: linux
@@ -63,7 +63,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm64"
   - use: buildx
     goos: linux
@@ -79,7 +79,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ archives:
   - id: default
     builds:
       - default
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
@@ -71,7 +71,7 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
@@ -83,11 +83,11 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}'
+    name_template: '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}'
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
   #- use: docker
   #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
   #  image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,4 @@
 dist: releases
-env:
-  - PACKAGE=github.com/rebuy-de/aws-nuke
 release:
   github:
     owner: rebuy-de

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,8 @@ docker_manifests:
   #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Summary }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,8 +55,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -83,17 +83,17 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}'
+    name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
   #- use: docker
-  #  name_template: '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}'
+  #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
-      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -85,15 +85,15 @@ docker_manifests:
   - use: docker
     name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
   #- use: docker
   #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -56,7 +56,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -72,7 +72,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -88,12 +88,12 @@ docker_manifests:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
-  - use: docker
-    name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
-    image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+  #- use: docker
+  #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+  #  image_templates:
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,14 +24,14 @@ builds:
         goarch: arm
     ldflags:
       - -s
-      - -X '{{ .ModulePath }}/cmd.BuildVersion={{ .Version }}'
+      - -X '{{ .ModulePath }}/cmd.BuildVersion=v{{ .Version }}'
       - -X '{{ .ModulePath }}/cmd.BuildDate={{ .Date }}'
       - -X '{{ .ModulePath }}/cmd.BuildHash={{ .Commit }}'
 archives:
   - id: default
     builds:
       - default
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
     format_overrides:
       - goos: windows
         format: zip
@@ -41,14 +41,14 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+      #- quay.io/rebuy/aws-nuke:v{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/amd64"
   - use: buildx
@@ -56,14 +56,14 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+      #- quay.io/rebuy/aws-nuke:v{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm64"
   - use: buildx
@@ -72,29 +72,29 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
-      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
+      #- quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: ghcr.io/rebuy-de/aws-nuke:{{ .Version }}
+    name_template: ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
   #- use: docker
-  #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
+  #  name_template: quay.io/rebuy-de/aws-nuke:v{{ .Version }}
   #  image_templates:
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,106 @@
+dist: releases
+env:
+  - PACKAGE=github.com/rebuy-de/aws-nuke
+release:
+  github:
+    owner: rebuy-de
+    name: aws-nuke
+builds:
+  - id: default
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
+    ldflags:
+      - -s
+      - -X '{{ .ModulePath }}/cmd.BuildVersion={{ .Version }}'
+      - -X '{{ .ModulePath }}/cmd.BuildDate={{ .Date }}'
+      - -X '{{ .ModulePath }}/cmd.BuildHash={{ .Commit }}'
+archives:
+  - id: default
+    builds:
+      - default
+    format_overrides:
+      - goos: windows
+        format: zip
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/arm64"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/arm/v7"
+docker_manifests:
+  - use: docker
+    name_template: '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}'
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+  - use: docker
+    name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+    image_templates:
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -71,7 +71,7 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
       #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
@@ -83,11 +83,11 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
+    name_template: ghcr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
   #- use: docker
   #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,8 +55,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -83,17 +83,17 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}'
+    name_template: '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}'
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
   #- use: docker
-  #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+  #  name_template: '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}'
   #  image_templates:
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ archives:
   - id: default
     builds:
       - default
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,6 +4,6 @@ ENTRYPOINT ["/usr/local/bin/aws-nuke"]
 RUN apk add --no-cache ca-certificates
 RUN adduser -D aws-nuke
 
-COPY aws-nuke /usr/local/bin/aws-nuk
+COPY aws-nuke /usr/local/bin/aws-nuke
 
 USER aws-nuke

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,9 @@
+
+FROM alpine:3.14.3
+ENTRYPOINT ["/usr/local/bin/aws-nuke"]
+RUN apk add --no-cache ca-certificates
+RUN adduser -D aws-nuke
+
+COPY aws-nuke /usr/local/bin/aws-nuk
+
+USER aws-nuke


### PR DESCRIPTION
## Overview

I think it would be worth considering merging this in to standardize builds, while the makefile is great, it doesn't cover release asset upload and docker builds, where goreleaser does.

This is a great tool that makes releasing golang based projects very simple.  This configuration is setup to build the same set of binaries already being built, but it also adds building docker images for each linux based build including arm, then publishing a manifest so a single docker pull will work on amd64, arm64, or arm32v7. This can easily be expanded to support other architectures.

## Differences

- Files within archive are just named `aws-nuke` instead of matching the name of the archive

## Testing 

If you'd like to take it for a test run you can simply clone my branch and run `gorelease release --rm-dist --snapshot` and it'll build everything locally for you.

## Releasing 

Performing a release then becomes as simple as cutting a tag and running the tool **OR** better yet using the GitHub Action.

```bash
git tag -a v2.17.0-rc1 -m 'Release v2.17.0-rc1'
git push --tags
goreleaser release --rm-dist
```

### GitHub Actions Support

**Important:** there is a github action that can be installed on GitHub Actions, if you go that route, then you simply need to only tag and push tags and GitHub Actions will take care of the rest via GitHub Actions.

## Example

You can see https://github.com/ekristen/aws-nuke/releases/tag/v2.17.0-ek.2 as an example

I did this branch because I needed a way to build releases of improvements I'm making since they haven't been merged into the main branch on the main repository. This coupled with a small bash script lets me sed replace the `debuy-de` with `ekristen` and publish under my fork, as the above link shows.

Try this from amd64, arm64 or arm32v7, and you should get the following back.

```bash
docker run -it --rm ghcr.io/ekristen/aws-nuke:2.17.0-ek.1 version
```

```
version:     2.17.0-ek.1
build date:  2021-11-22T22:43:03Z
scm hash:    885c7d50a103d5ffb9cee32b77a2f053ffd65e6d
environment: unknown
```