### PR TITLE
Ignore inaccessible policies

### DIFF
--- a/resources/iam-policies.go
+++ b/resources/iam-policies.go
@@ -44,7 +44,7 @@ func ListIAMPolicies(sess *session.Session) ([]Resource, error) {
 				policy, err := GetIAMPolicy(svc, listedPolicy.Arn)
 				if err != nil {
 					logrus.Errorf("Failed to get listed policy %s: %v", *listedPolicy.PolicyName, err)
-					break
+					continue
 				}
 				policies = append(policies, policy)
 			}


### PR DESCRIPTION
In some AWS organizations IAM polices may be inaccessible to the person
running aws-nuke. Log the errors and continue. Currently, if a policy is not accessible to the user no policies can be nuked.