### PR TITLE
Disable GlobalAccelerator before deleting it

### DIFF
--- a/resources/ga-accelerators.go
+++ b/resources/ga-accelerators.go
@@ -51,7 +51,22 @@ func ListGlobalAccelerators(sess *session.Session) ([]Resource, error) {
 
 // Remove resource
 func (ga *GlobalAccelerator) Remove() error {
-	_, err := ga.svc.DeleteAccelerator(&globalaccelerator.DeleteAcceleratorInput{
+	accel, err := ga.svc.DescribeAccelerator(&globalaccelerator.DescribeAcceleratorInput{
+		AcceleratorArn: ga.ARN,
+	})
+	if err != nil {
+		return err
+	}
+	if *accel.Accelerator.Enabled {
+		_, err := ga.svc.UpdateAccelerator(&globalaccelerator.UpdateAcceleratorInput{
+			AcceleratorArn: ga.ARN,
+			Enabled:        aws.Bool(false),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	_, err = ga.svc.DeleteAccelerator(&globalaccelerator.DeleteAcceleratorInput{
 		AcceleratorArn: ga.ARN,
 	})
 


### PR DESCRIPTION
The Global Accelerator resource needs to be disabled before deleting it. This change will disable the accelerator if it is enabled so it can be deleted. 