### PR TITLE
Add tag outputs for the EFSFileSystem, EKSCluster, EKSNodegroup and ESDomain resources

### DIFF
--- a/resources/eks-nodegroups.go
+++ b/resources/eks-nodegroups.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -10,10 +11,8 @@ import (
 )
 
 type EKSNodegroup struct {
-	svc     *eks.EKS
-	cluster *string
-	name    *string
-	tags    map[string]*string
+	svc       *eks.EKS
+	nodegroup *eks.Nodegroup
 }
 
 func init() {
@@ -50,10 +49,12 @@ func ListEKSNodegroups(sess *session.Session) ([]Resource, error) {
 	nodegroupsInputParams := &eks.ListNodegroupsInput{
 		MaxResults: aws.Int64(100),
 	}
+	describeNodegroupInputParams := &eks.DescribeNodegroupInput{}
 
 	// fetch the associated node groups
 	for _, clusterName := range clusterNames {
 		nodegroupsInputParams.ClusterName = clusterName
+		describeNodegroupInputParams.ClusterName = clusterName
 
 		for {
 			resp, err := svc.ListNodegroups(nodegroupsInputParams)
@@ -61,18 +62,15 @@ func ListEKSNodegroups(sess *session.Session) ([]Resource, error) {
 				return nil, err
 			}
 
-			for _, name := range resp.Nodegroups {
-				dngo, err := svc.DescribeNodegroup(
-					&eks.DescribeNodegroupInput{ClusterName: clusterName, NodegroupName: name})
+			for _, nodegroupName := range resp.Nodegroups {
+				describeNodegroupInputParams.NodegroupName = nodegroupName
+				nodegroupDescriptionResponse, err := svc.DescribeNodegroup(describeNodegroupInputParams)
 				if err != nil {
 					return nil, err
 				}
-
 				resources = append(resources, &EKSNodegroup{
-					svc:     svc,
-					name:    name,
-					cluster: clusterName,
-					tags:    dngo.Nodegroup.Tags,
+					svc:       svc,
+					nodegroup: nodegroupDescriptionResponse.Nodegroup,
 				})
 			}
 
@@ -83,7 +81,6 @@ func ListEKSNodegroups(sess *session.Session) ([]Resource, error) {
 
 			nodegroupsInputParams.NextToken = resp.NextToken
 		}
-
 	}
 
 	return resources, nil
@@ -91,22 +88,25 @@ func ListEKSNodegroups(sess *session.Session) ([]Resource, error) {
 
 func (ng *EKSNodegroup) Remove() error {
 	_, err := ng.svc.DeleteNodegroup(&eks.DeleteNodegroupInput{
-		ClusterName:   ng.cluster,
-		NodegroupName: ng.name,
+		ClusterName:   ng.nodegroup.ClusterName,
+		NodegroupName: ng.nodegroup.NodegroupName,
 	})
 	return err
 }
 
 func (ng *EKSNodegroup) Properties() types.Properties {
 	properties := types.NewProperties()
-	for k, v := range ng.tags {
+	properties.Set("Cluster", ng.nodegroup.ClusterName)
+	properties.Set("Profile", ng.nodegroup.NodegroupName)
+	if ng.nodegroup.CreatedAt != nil {
+		properties.Set("CreatedAt", ng.nodegroup.CreatedAt.Format(time.RFC3339))
+	}
+	for k, v := range ng.nodegroup.Tags {
 		properties.SetTag(&k, v)
 	}
-	properties.Set("Cluster", *ng.cluster)
-	properties.Set("Profile", *ng.name)
 	return properties
 }
 
 func (ng *EKSNodegroup) String() string {
-	return fmt.Sprintf("%s:%s", *ng.cluster, *ng.name)
+	return fmt.Sprintf("%s:%s", *ng.nodegroup.ClusterName, *ng.nodegroup.NodegroupName)
 }

--- a/resources/eks-nodegroups.go
+++ b/resources/eks-nodegroups.go
@@ -13,7 +13,7 @@ type EKSNodegroup struct {
 	svc     *eks.EKS
 	cluster *string
 	name    *string
-	tagList []*eks.Tag
+	tags    map[string]*string
 }
 
 func init() {
@@ -67,15 +67,12 @@ func ListEKSNodegroups(sess *session.Session) ([]Resource, error) {
 				if err != nil {
 					return nil, err
 				}
-				lto, err := svc.ListTagsForResource(&eks.ListTagsForResourceInput{ResourceArn: dngo.Nodegroup.NodegroupArn})
-				if err != nil {
-					return nil, err
-				}
+
 				resources = append(resources, &EKSNodegroup{
 					svc:     svc,
 					name:    name,
 					cluster: clusterName,
-					tagList: lto.Tags,
+					tags:    dngo.Nodegroup.Tags,
 				})
 			}
 
@@ -102,11 +99,11 @@ func (ng *EKSNodegroup) Remove() error {
 
 func (ng *EKSNodegroup) Properties() types.Properties {
 	properties := types.NewProperties()
-	for _, t := range ng.tagList {
-		properties.SetTag(t.Key, t.Value)
+	for k, v := range ng.tags {
+		properties.SetTag(&k, v)
 	}
-	Set("Cluster", *ng.cluster).
-		Set("Profile", *ng.name)
+	properties.Set("Cluster", *ng.cluster)
+	properties.Set("Profile", *ng.name)
 	return properties
 }
 

--- a/resources/elasticsearchservice-domain.go
+++ b/resources/elasticsearchservice-domain.go
@@ -8,6 +8,7 @@ import (
 type ESDomain struct {
 	svc        *elasticsearchservice.ElasticsearchService
 	domainName *string
+	tagList    []*elasticsearchservice.Tag
 }
 
 func init() {
@@ -25,9 +26,19 @@ func ListESDomains(sess *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, domain := range resp.DomainNames {
+		dedo, err := svc.DescribeElasticsearchDomain(
+			&elasticsearchservice.DescribeElasticsearchDomainInput{DomainName: domain.DomainName})
+		if err != nil {
+			return nil, err
+		}
+		lto, err := svc.ListTags(&elasticsearchservice.ListTagsInput{ARN: dedo.DomainStatus.ARN})
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, &ESDomain{
 			svc:        svc,
 			domainName: domain.DomainName,
+			tagList:    lto.TagList,
 		})
 	}
 

--- a/resources/elasticsearchservice-domain.go
+++ b/resources/elasticsearchservice-domain.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
 )
 
 type ESDomain struct {
@@ -52,6 +53,14 @@ func (f *ESDomain) Remove() error {
 	})
 
 	return err
+}
+
+func (f *ESDomain) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, t := range f.tagList {
+		properties.SetTag(t.Key, t.Value)
+	}
+	return properties
 }
 
 func (f *ESDomain) String() string {


### PR DESCRIPTION
Just as stated in the title, this PR will add the option to output tags for the EFSFileSystem, EKSCluster, EKSNodegroup and ESDomain resources.

Proof:

![image](https://user-images.githubusercontent.com/85991071/148399695-80dcd6b0-cf71-47fc-93f7-e74aafd8e342.png)
