### PR TITLE
feat: support new resource ec2 host

### DIFF
--- a/resources/ec2-hosts.go
+++ b/resources/ec2-hosts.go
@@ -1,0 +1,89 @@
+package resources
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/pkg/config"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+)
+
+type EC2Host struct {
+	svc  *ec2.EC2
+	host *ec2.Host
+
+	featureFlags config.FeatureFlags
+}
+
+func init() {
+	register("EC2Host", ListEC2Hosts)
+}
+
+func ListEC2Hosts(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	params := &ec2.DescribeHostsInput{}
+	resources := make([]Resource, 0)
+	for {
+		resp, err := svc.DescribeHosts(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, host := range resp.Hosts {
+			resources = append(resources, &EC2Host{
+				svc:  svc,
+				host: host,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params = &ec2.DescribeHostsInput{
+			NextToken: resp.NextToken,
+		}
+	}
+
+	return resources, nil
+}
+
+func (i *EC2Host) Filter() error {
+	if *i.host.State == "released" {
+		return fmt.Errorf("already released")
+	}
+	return nil
+}
+
+func (i *EC2Host) Remove() error {
+	params := &ec2.ReleaseHostsInput{
+		HostIds: []*string{i.host.HostId},
+	}
+
+	_, err := i.svc.ReleaseHosts(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *EC2Host) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Identifier", i.host.HostId)
+	properties.Set("HostInstanceFamily", i.host.HostProperties.InstanceFamily)
+	properties.Set("HostCores", i.host.HostProperties.Cores)
+	properties.Set("HostState", i.host.State)
+	properties.Set("AllocationTime", i.host.AllocationTime.Format(time.RFC3339))
+
+	for _, tagValue := range i.host.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+
+	return properties
+}
+
+func (i *EC2Host) String() string {
+	return *i.host.HostId
+}


### PR DESCRIPTION
This PR adds support of nuking the new resource type: [EC2 Host](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#Host), aka Dedicated Host. All SDK and AWS API are using term of `Host` instead `DedicatedHost`.

```yaml
resource-types:
  targets:
  - EC2Host
```

Test run from locally built `aws-nuke`:
```
❯ ./dist/aws-nuke -c config/custom-example.yaml --no-dry-run
aws-nuke version v2.17.0.dirty - Wed Jan 26 17:43:50 AEDT 2022 - 4f8848fdb9358fc2a8b8c4a59c424febde09a409

Do you really want to nuke the account with the ID 000000000000 and the alias 'xxxxxx'?
Do you want to continue? Enter account alias to continue.
> xxxxxx

us-east-1 - EC2Host - h-04f0853e77220238e - [AllocationTime: "2022-01-26T07:29:15Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-04f0853e77220238e", tag:Name: "nuketest2"] - would remove
us-east-1 - EC2Host - h-0bd93013a6e634da7 - [AllocationTime: "2022-01-26T07:29:02Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-0bd93013a6e634da7", tag:Name: "nuketest"] - would remove
us-east-1 - EC2Host - h-0b03d4d18b6669d50 - [AllocationTime: "2022-01-26T07:26:43Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "released", Identifier: "h-0b03d4d18b6669d50", tag:Name: "asdf"] - already released
Scan complete: 3 total, 2 nukeable, 1 filtered.

Do you really want to nuke these resources on the account with the ID 000000000000 and the alias 'xxxxxx'?
Do you want to continue? Enter account alias to continue.
> xxxxxx

us-east-1 - EC2Host - h-04f0853e77220238e - [AllocationTime: "2022-01-26T07:29:15Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-04f0853e77220238e", tag:Name: "nuketest2"] - triggered remove
us-east-1 - EC2Host - h-0bd93013a6e634da7 - [AllocationTime: "2022-01-26T07:29:02Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-0bd93013a6e634da7", tag:Name: "nuketest"] - triggered remove

Removal requested: 2 waiting, 0 failed, 1 skipped, 0 finished

us-east-1 - EC2Host - h-04f0853e77220238e - [AllocationTime: "2022-01-26T07:29:15Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-04f0853e77220238e", tag:Name: "nuketest2"] - waiting
us-east-1 - EC2Host - h-0bd93013a6e634da7 - [AllocationTime: "2022-01-26T07:29:02Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-0bd93013a6e634da7", tag:Name: "nuketest"] - waiting

Removal requested: 2 waiting, 0 failed, 1 skipped, 0 finished

us-east-1 - EC2Host - h-04f0853e77220238e - [AllocationTime: "2022-01-26T07:29:15Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-04f0853e77220238e", tag:Name: "nuketest2"] - removed
us-east-1 - EC2Host - h-0bd93013a6e634da7 - [AllocationTime: "2022-01-26T07:29:02Z", HostCores: "48", HostInstanceFamily: "t3", HostState: "available", Identifier: "h-0bd93013a6e634da7", tag:Name: "nuketest"] - removed

Removal requested: 0 waiting, 0 failed, 1 skipped, 2 finished

Nuke complete: 0 failed, 1 skipped, 2 finished.
```

CloudTrail events confirmed the `ReleaseHosts` calls were made:

![image](https://user-images.githubusercontent.com/5382613/151121562-b5538901-c2b1-4e58-90a1-e13580d39553.png)

EC2 confirmed the hosts were released:

![image](https://user-images.githubusercontent.com/5382613/151121641-4e321276-07e4-49bb-9736-bc5d8e90be14.png)

Note: Some host types cannot be released within 24 hours since allocation. In this case, `aws-nuke` would eventually fail, but expected.
