### PR TITLE
fix: instanceprofilerolebug

### DIFF
--- a/resources/iam-instance-profile-roles.go
+++ b/resources/iam-instance-profile-roles.go
@@ -73,7 +73,7 @@ func (e *IAMInstanceProfileRole) Remove() error {
 }
 
 func (e *IAMInstanceProfileRole) String() string {
-	return fmt.Sprintf("%s -> %s", e.profile, e.role)
+	return fmt.Sprintf("%s -> %s", *e.profile.InstanceProfileName, e.role)
 }
 
 func (e *IAMInstanceProfileRole) Properties() types.Properties {


### PR DESCRIPTION
When scanning the IAMInstanceProfileRole Nuke is currently displaying a lot of of data in addition and not just the the ProfileRole.  

This breaks the functionality, and old configs will not filter any of the IAMInstanceProfileRole. 
 This should be fixed ASAP.