### PR TITLE
Remove armv7 builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       id: qemu
       uses: docker/setup-qemu-action@v1
       with:
-        platforms: arm64,arm/v7
+        platforms: arm64
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -75,4 +75,4 @@ jobs:
         context: .
         push: true
         tags: ${{ steps.generate_tags.outputs.tags }}
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I needed to start the v2.17.0 release action about 8 times before it was successful. Not sure if we are doing anything wrong, but easiest would be to remove the separate build step. Since Raspberry Pi OS is finally [available in 64 Bit](https://www.phoronix.com/scan.php?page=news_item&px=Raspbian-OS-64-bit) most users should be able to use the arm64 image.