### PR TITLE
dateOlderThan will not fatal error on datetime parse failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ feature-flags:
     EC2Instance: true
     CloudformationStack: true
   force-delete-lightsail-addons: true
+  nuke-on-filter-failure: true
 ```
 
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	ReasonSkip            = *color.New(color.FgYellow)
+	ReasonSkipFailed      = *color.New(color.FgMagenta)
 	ReasonError           = *color.New(color.FgRed)
 	ReasonRemoveTriggered = *color.New(color.FgGreen)
 	ReasonWaitPending     = *color.New(color.FgBlue)

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -15,6 +15,7 @@ const (
 	ItemStateWaiting
 	ItemStateFailed
 	ItemStateFiltered
+	ItemStateFilterFailed
 	ItemStateFinished
 )
 
@@ -42,6 +43,8 @@ func (i *Item) Print() {
 		Log(i.Region, i.Type, i.Resource, ReasonError, "failed")
 	case ItemStateFiltered:
 		Log(i.Region, i.Type, i.Resource, ReasonSkip, i.Reason)
+	case ItemStateFilterFailed:
+		Log(i.Region, i.Type, i.Resource, ReasonSkipFailed, i.Reason)
 	case ItemStateFinished:
 		Log(i.Region, i.Type, i.Resource, ReasonSuccess, "removed")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type Nuke struct {
 type FeatureFlags struct {
 	DisableDeletionProtection  DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	ForceDeleteLightsailAddOns bool                      `yaml:"force-delete-lightsail-addons"`
+	NukeOnFilterFailure        bool                      `yaml:"nuke-on-filter-failure"`
 }
 
 type DisableDeletionProtection struct {

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -67,7 +67,7 @@ func (f Filter) Match(o string) (bool, error) {
 		}
 		fieldTime, err := parseDate(o)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		fieldTimeWithOffset := fieldTime.Add(duration)
 

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -31,16 +31,16 @@ func (f Filters) Merge(f2 Filters) {
 }
 
 type FilterFailed struct{
-	Filter string //?
-	Fatal bool
-	Err error
+	Filter string	//What Filter Failed?
+	Fatal bool		//Is this life threating?
+	Err error		//What caused it?
 }
 
 func (f *FilterFailed) Error() string {
 	return fmt.Sprintf("filter: %v isFatal?: %t err: %v", f.Filter, f.Fatal, f.Err)
 }
 
-
+//creates a FillterFailed with a custom message
 func createFilterFailed(filter string, fatal bool, msg string) error {
 	return &FilterFailed{
 		Filter: filter,
@@ -88,13 +88,13 @@ func (f Filter) Match(o string) (bool, error) {
 		}
 		fieldTime, err := parseDate(o)
 		if err != nil {
-			var ferr = &FilterFailed{
+			var fferr = &FilterFailed{
 				Filter: FilterTypeDateOlderThan,
 				Fatal: false,
 				Err: err,
 			}
 
-			return false, ferr
+			return false, fferr
 		}
 		fieldTimeWithOffset := fieldTime.Add(duration)
 


### PR DESCRIPTION
I encountered a problem where, if the tag of a resource couldn't be parsed as a date (e.g tag: Expirationdate: "IamNotADate") the service module would fatal error wit "Error: unable to parse time IamNotADate".

This would normally be fine but sadly it errors out the entire module, so if the bad date was in a single EC2 instances the entire EC2Instance module stops and no EC2 instances gets filtered or deleted.

This fixes the problem but we might need to add a message to the user that a tag was not parsed and therefor the resource was not filtered.