### PR TITLE
fix(EC2NetworkInterface): fix panic on not attached NetworkInterfaces…

### DIFF
--- a/resources/ec2-network-interfaces.go
+++ b/resources/ec2-network-interfaces.go
@@ -47,10 +47,13 @@ func (e *EC2NetworkInterface) Remove() error {
 			Force:        aws.Bool(true),
 		})
 		if err != nil {
-			expected := fmt.Sprintf("The interface attachment '%s' does not exist.", *e.eni.Attachment.AttachmentId)
-			if !strings.Contains(err.Error(), expected) {
-				return err
+			if e.eni.Attachment.AttachmentId != nil {
+				expected := fmt.Sprintf("The interface attachment '%s' does not exist.", *e.eni.Attachment.AttachmentId)
+				if !strings.Contains(err.Error(), expected) {
+					return err
+				}
 			}
+
 		}
 	}
 


### PR DESCRIPTION
It is possible, that an interface is not attached. This leads to the fact that no AttachmendId is available. Accordingly, the string can also not be accessed.

<img width="1107" alt="Screenshot 2022-03-04 at 07 36 47" src="https://user-images.githubusercontent.com/65007683/156712816-0620fe50-9f11-484b-be19-ddc5953d3bc1.png">

