### PR TITLE
add support for cloud control

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,51 @@ If an exclude is used, then all its resource types will not be deleted.
 aws-nuke resource-types
 ```
 
+### AWS Cloud Control API Support
+
+> This feature is not yet released and is probably part of `v2.18`.
+
+_aws-nuke_ supports removing resources via the AWS Cloud Control API. When
+executing _aws-nuke_ it will automatically remove a manually managed set of
+resources via Cloud Control.
+
+Only a subset of Cloud Control supported resources will be removed
+automatically, because there might be resources that were already implemented
+and adding them too would bypass existing filters in user configs as Cloud
+Control has another naming scheme and a different set of properties. Moreover,
+there are some Cloud Control resources that need special handling which is not
+yet supported by _aws-nuke_.
+
+Even though the subset of automatically supported Cloud Control resources is
+limited, you can can configure _aws-nuke_ to make it try any additional
+resource. Either via command line flags of via the config file.
+
+For the config file you have to add the resource to
+the`resource-types.cloud-control` list:
+
+```yaml
+resource-types:
+  cloud-control:
+  - AWS::EC2::TransitGateway
+  - AWS::EC2::VPC
+```
+
+If you want to use the command line, you have to add a `--cloud-control` flag
+for each resource you want to add:
+
+```sh
+aws-nuke \
+    -c nuke-config.yaml \
+    --cloud-control AWS::EC2::TransitGateway \
+    --cloud-control AWS::EC2::VPC
+```
+
+**Note:** There are some resources that are supported by Cloud Control and are
+already natively implemented by _aws-nuke_. If you configure to use Cloud
+Control for those resources, it will not execute the natively implemented code
+for this resource. For example with the `--cloud-control AWS::EC2::VPC` it will
+not use the `EC2VPC` resource.
+
 
 ### Feature Flags
 
@@ -460,9 +505,9 @@ There are also additional comparision types than an exact match:
   Details about the syntax can be found in the [library
   documentation](https://golang.org/pkg/regexp/syntax/).
 * `dateOlderThan` - The identifier is parsed as a timestamp. After the offset is added to it (specified in the `value` field), the resulting timestamp must be AFTER the current
-  time. Details on offset syntax can be found in 
+  time. Details on offset syntax can be found in
   the [library documentation](https://golang.org/pkg/time/#ParseDuration). Supported
-  date formats are epoch time, `2006-01-02`, `2006/01/02`, `2006-01-02T15:04:05Z`, 
+  date formats are epoch time, `2006-01-02`, `2006/01/02`, `2006-01-02T15:04:05Z`,
   `2006-01-02T15:04:05.999999999Z07:00`, and `2006-01-02T15:04:05Z07:00`.
 
 To use a non-default comparision type, it is required to specify an object with
@@ -561,13 +606,13 @@ presets:
 The easiest way of installing it, is to download the latest
 [release](https://github.com/rebuy-de/aws-nuke/releases) from GitHub.
 
-#### Example for Linux Intel/AMD 
+#### Example for Linux Intel/AMD
 
 Download and extract
 `$ wget -c https://github.com/rebuy-de/aws-nuke/releases/download/v2.16.0/aws-nuke-v2.16.0-linux-amd64.tar.gz -O - | sudo tar -xz -C $HOME/bin`
 
 Run
-`$ aws-nuke-v2.16.0-linux-amd64` 
+`$ aws-nuke-v2.16.0-linux-amd64`
 
 ### Compile from Source
 

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -139,6 +139,7 @@ func (n *Nuke) Scan() error {
 
 	resourceTypes := ResolveResourceTypes(
 		resources.GetListerNames(),
+		resources.GetCloudControlMapping(),
 		[]types.Collection{
 			n.Parameters.Targets,
 			n.Config.ResourceTypes.Targets,
@@ -148,6 +149,11 @@ func (n *Nuke) Scan() error {
 			n.Parameters.Excludes,
 			n.Config.ResourceTypes.Excludes,
 			accountConfig.ResourceTypes.Excludes,
+		},
+		[]types.Collection{
+			n.Parameters.CloudControl,
+			n.Config.ResourceTypes.CloudControl,
+			accountConfig.ResourceTypes.CloudControl,
 		},
 	)
 

--- a/cmd/params.go
+++ b/cmd/params.go
@@ -8,8 +8,9 @@ import (
 type NukeParameters struct {
 	ConfigPath string
 
-	Targets  []string
-	Excludes []string
+	Targets      []string
+	Excludes     []string
+	CloudControl []string
 
 	NoDryRun   bool
 	Force      bool

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -49,12 +49,12 @@ func (i *Item) Print() {
 
 // List gets all resource items of the same resource type like the Item.
 func (i *Item) List() ([]resources.Resource, error) {
-	listers := resources.GetListers()
+	lister := resources.GetLister(i.Type)
 	sess, err := i.Region.Session(i.Type)
 	if err != nil {
 		return nil, err
 	}
-	return listers[i.Type](sess)
+	return lister(sess)
 }
 
 func (i *Item) GetProperty(key string) (string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,7 @@ func NewRootCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(
 		&creds.AssumeRoleArn, "assume-role-arn", "",
 		"AWS IAM role arn to assume. "+
-		    "The credentials provided via --access-key-id or --profile must "+
+			"The credentials provided via --access-key-id or --profile must "+
 			"be allowed to assume this role. ")
 	command.PersistentFlags().StringVar(
 		&defaultRegion, "default-region", "",
@@ -133,6 +133,12 @@ func NewRootCommand() *cobra.Command {
 	command.PersistentFlags().StringSliceVarP(
 		&params.Excludes, "exclude", "e", []string{},
 		"Prevent nuking of certain resource types (eg IAMServerCertificate). "+
+			"This flag can be used multiple times.")
+	command.PersistentFlags().StringSliceVar(
+		&params.CloudControl, "cloud-control", []string{},
+		"Nuke given resource via Cloud Control API. "+
+			"If there is an old-style method for the same resource, the old-style one will not be executed. "+
+			"Note that old-style and cloud-control filters are not compatible! "+
 			"This flag can be used multiple times.")
 	command.PersistentFlags().BoolVar(
 		&params.NoDryRun, "no-dry-run", false,

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -25,7 +25,23 @@ func Prompt(expect string) error {
 	return nil
 }
 
-func ResolveResourceTypes(base types.Collection, include, exclude []types.Collection) types.Collection {
+func ResolveResourceTypes(
+	base types.Collection, mapping map[string]string,
+	include, exclude, cloudControl []types.Collection) types.Collection {
+
+	for _, cl := range cloudControl {
+		oldStyle := types.Collection{}
+		for _, c := range cl {
+			os, found := mapping[c]
+			if found {
+				oldStyle = append(oldStyle, os)
+			}
+		}
+
+		base = base.Union(cl)
+		base = base.Remove(oldStyle)
+	}
+
 	for _, i := range include {
 		if len(i) > 0 {
 			base = base.Intersect(i)

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -10,42 +10,58 @@ import (
 
 func TestResolveResourceTypes(t *testing.T) {
 	cases := []struct {
-		base    types.Collection
-		include []types.Collection
-		exclude []types.Collection
-		result  types.Collection
+		name         string
+		base         types.Collection
+		mapping      map[string]string
+		include      []types.Collection
+		exclude      []types.Collection
+		cloudControl []types.Collection
+		result       types.Collection
 	}{
 		{
 			base:    types.Collection{"a", "b", "c", "d"},
-			include: []types.Collection{types.Collection{"a", "b", "c"}},
+			include: []types.Collection{{"a", "b", "c"}},
 			result:  types.Collection{"a", "b", "c"},
 		},
 		{
 			base:    types.Collection{"a", "b", "c", "d"},
-			exclude: []types.Collection{types.Collection{"b", "d"}},
+			exclude: []types.Collection{{"b", "d"}},
 			result:  types.Collection{"a", "c"},
 		},
 		{
 			base:    types.Collection{"a", "b"},
-			include: []types.Collection{types.Collection{}},
+			include: []types.Collection{{}},
 			result:  types.Collection{"a", "b"},
 		},
 		{
 			base:    types.Collection{"c", "b"},
-			exclude: []types.Collection{types.Collection{}},
+			exclude: []types.Collection{{}},
 			result:  types.Collection{"c", "b"},
 		},
 		{
 			base:    types.Collection{"a", "b", "c", "d"},
-			include: []types.Collection{types.Collection{"a", "b", "c"}},
-			exclude: []types.Collection{types.Collection{"a"}},
+			include: []types.Collection{{"a", "b", "c"}},
+			exclude: []types.Collection{{"a"}},
 			result:  types.Collection{"b", "c"},
+		},
+		{
+			name:         "CloudControlAdd",
+			base:         types.Collection{"a", "b"},
+			cloudControl: []types.Collection{{"x"}},
+			result:       types.Collection{"a", "b", "x"},
+		},
+		{
+			name:         "CloudControlReplaceOldStyle",
+			base:         types.Collection{"a", "b", "c"},
+			mapping:      map[string]string{"z": "b"},
+			cloudControl: []types.Collection{{"z"}},
+			result:       types.Collection{"a", "z", "c"},
 		},
 	}
 
-	for i, tc := range cases {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			r := ResolveResourceTypes(tc.base, tc.include, tc.exclude)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := ResolveResourceTypes(tc.base, tc.mapping, tc.include, tc.exclude, tc.cloudControl)
 
 			sort.Strings(r)
 			sort.Strings(tc.result)
@@ -72,7 +88,7 @@ func TestIsTrue(t *testing.T) {
 
 	trueStrings := []string{"true", " true", "true ", " TrUe "}
 	for _, ts := range trueStrings {
-		if ! IsTrue(ts) {
+		if !IsTrue(ts) {
 			t.Fatalf("IsTrue falsely returned 'false' for: %s", ts)
 		}
 	}

--- a/dev/list-cloudcontrol/main.go
+++ b/dev/list-cloudcontrol/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/fatih/color"
+	"github.com/rebuy-de/aws-nuke/resources"
+	"github.com/rebuy-de/rebuy-go-sdk/v3/pkg/cmdutil"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	ctx := cmdutil.SignalRootContext()
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(endpoints.UsEast1RegionID),
+	})
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	cf := cloudformation.New(sess)
+
+	mapping := resources.GetCloudControlMapping()
+
+	in := &cloudformation.ListTypesInput{
+		Type:             aws.String(cloudformation.RegistryTypeResource),
+		Visibility:       aws.String(cloudformation.VisibilityPublic),
+		ProvisioningType: aws.String(cloudformation.ProvisioningTypeFullyMutable),
+	}
+
+	err = cf.ListTypesPagesWithContext(ctx, in, func(out *cloudformation.ListTypesOutput, _ bool) bool {
+		if out == nil {
+			return true
+		}
+
+		for _, summary := range out.TypeSummaries {
+			if summary == nil {
+				continue
+			}
+
+			typeName := aws.StringValue(summary.TypeName)
+			color.New(color.Bold).Printf("%-55s", typeName)
+			if !strings.HasPrefix(typeName, "AWS::") {
+				color.HiBlack("does not have a valid prefix")
+				continue
+			}
+
+			resourceName, exists := mapping[typeName]
+			if exists && resourceName == typeName {
+				fmt.Print("is only covered by ")
+				color.New(color.FgGreen, color.Bold).Println(resourceName)
+				continue
+			} else if exists {
+				fmt.Print("is also covered by ")
+				color.New(color.FgBlue, color.Bold).Println(resourceName)
+				continue
+			}
+
+			color.New(color.FgYellow).Println("is not configured")
+		}
+
+		return true
+	})
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
 	github.com/pkg/errors v0.9.1
+	github.com/rebuy-de/rebuy-go-sdk/v3 v3.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
@@ -17,6 +18,8 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gemnasium/logrus-graylog-hook/v3 v3.0.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -25,7 +28,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
-	golang.org/x/tools v0.1.5 // indirect
+	golang.org/x/tools v0.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/gemnasium/logrus-graylog-hook/v3 v3.0.3 h1:YQHp/LxUTeZhgnXKbJASRii315h+HWtPd5ctewP4Pms=
+github.com/gemnasium/logrus-graylog-hook/v3 v3.0.3/go.mod h1:wi1zWv9tIvyLSMLCAzgRP+YR24oLVQVBHfPPKjtht44=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -189,6 +191,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -308,6 +312,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/rebuy-de/rebuy-go-sdk/v3 v3.11.0 h1:kjWGsRRl6x0dMjU8PQajgd5woDdCC7dW17B9+JGnBho=
+github.com/rebuy-de/rebuy-go-sdk/v3 v3.11.0/go.mod h1:imLjgHMb9XZeZ2Cj6BEOdEuwkdUyOgDN4oBcSZthzro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -315,6 +321,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -610,8 +617,9 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.7 h1:6j8CgantCy3yc8JGBqkDLMKWqZ0RDU2g1HVgacojGWQ=
+golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,8 +12,9 @@ import (
 )
 
 type ResourceTypes struct {
-	Targets  types.Collection `yaml:"targets"`
-	Excludes types.Collection `yaml:"excludes"`
+	Targets      types.Collection `yaml:"targets"`
+	Excludes     types.Collection `yaml:"excludes"`
+	CloudControl types.Collection `yaml:"cloud-control"`
 }
 
 type Account struct {

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -16,6 +17,8 @@ func (p Properties) String() string {
 	for k, v := range p {
 		parts = append(parts, fmt.Sprintf(`%s: "%v"`, k, v))
 	}
+
+	sort.Strings(parts)
 
 	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
 }

--- a/resources/accessanalyzer-analyzers.go
+++ b/resources/accessanalyzer-analyzers.go
@@ -16,7 +16,8 @@ type AccessAnalyzer struct {
 }
 
 func init() {
-	register("AccessAnalyzer", ListAccessAnalyzer)
+	register("AccessAnalyzer", ListAccessAnalyzer,
+		mapCloudControl("AWS::AccessAnalyzer::Analyzer"))
 }
 
 func ListAccessAnalyzer(sess *session.Session) ([]Resource, error) {

--- a/resources/acmpca-certificateauthorities.go
+++ b/resources/acmpca-certificateauthorities.go
@@ -17,7 +17,8 @@ type ACMPCACertificateAuthority struct {
 }
 
 func init() {
-	register("ACMPCACertificateAuthority", ListACMPCACertificateAuthorities)
+	register("ACMPCACertificateAuthority", ListACMPCACertificateAuthorities,
+		mapCloudControl("AWS::ACMPCA::CertificateAuthority"))
 }
 
 func ListACMPCACertificateAuthorities(sess *session.Session) ([]Resource, error) {

--- a/resources/apigateway-apikeys.go
+++ b/resources/apigateway-apikeys.go
@@ -12,7 +12,8 @@ type APIGatewayAPIKey struct {
 }
 
 func init() {
-	register("APIGatewayAPIKey", ListAPIGatewayAPIKeys)
+	register("APIGatewayAPIKey", ListAPIGatewayAPIKeys,
+		mapCloudControl("AWS::ApiGateway::ApiKey"))
 }
 
 func ListAPIGatewayAPIKeys(sess *session.Session) ([]Resource, error) {

--- a/resources/apigateway-clientcertificates.go
+++ b/resources/apigateway-clientcertificates.go
@@ -12,7 +12,8 @@ type APIGatewayClientCertificate struct {
 }
 
 func init() {
-	register("APIGatewayClientCertificate", ListAPIGatewayClientCertificates)
+	register("APIGatewayClientCertificate", ListAPIGatewayClientCertificates,
+		mapCloudControl("AWS::ApiGateway::ClientCertificate"))
 }
 
 func ListAPIGatewayClientCertificates(sess *session.Session) ([]Resource, error) {

--- a/resources/apigateway-usageplans.go
+++ b/resources/apigateway-usageplans.go
@@ -15,7 +15,8 @@ type APIGatewayUsagePlan struct {
 }
 
 func init() {
-	register("APIGatewayUsagePlan", ListAPIGatewayUsagePlans)
+	register("APIGatewayUsagePlan", ListAPIGatewayUsagePlans,
+		mapCloudControl("AWS::ApiGateway::UsagePlan"))
 }
 
 func ListAPIGatewayUsagePlans(sess *session.Session) ([]Resource, error) {

--- a/resources/athena-named-queries.go
+++ b/resources/athena-named-queries.go
@@ -7,7 +7,8 @@ import (
 )
 
 func init() {
-	register("AthenaNamedQuery", ListAthenaNamedQueries)
+	register("AthenaNamedQuery", ListAthenaNamedQueries,
+		mapCloudControl("AWS::Athena::NamedQuery"))
 }
 
 type AthenaNamedQuery struct {

--- a/resources/athena-work-groups.go
+++ b/resources/athena-work-groups.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/athena"
@@ -12,7 +13,8 @@ import (
 )
 
 func init() {
-	register("AthenaWorkGroup", ListAthenaWorkGroups)
+	register("AthenaWorkGroup", ListAthenaWorkGroups,
+		mapCloudControl("AWS::Athena::WorkGroup"))
 }
 
 type AthenaWorkGroup struct {
@@ -81,7 +83,7 @@ func (a *AthenaWorkGroup) Remove() error {
 				PublishCloudWatchMetricsEnabled:  aws.Bool(false),
 				RemoveBytesScannedCutoffPerQuery: aws.Bool(true),
 				RequesterPaysEnabled:             aws.Bool(false),
-				ResultConfigurationUpdates:       &athena.ResultConfigurationUpdates{
+				ResultConfigurationUpdates: &athena.ResultConfigurationUpdates{
 					RemoveEncryptionConfiguration: aws.Bool(true),
 					RemoveOutputLocation:          aws.Bool(true),
 				},

--- a/resources/autoscaling-lifecyclehooks.go
+++ b/resources/autoscaling-lifecyclehooks.go
@@ -6,7 +6,8 @@ import (
 )
 
 func init() {
-	register("LifecycleHook", ListLifecycleHooks)
+	register("LifecycleHook", ListLifecycleHooks,
+		mapCloudControl("AWS::AutoScaling::LifecycleHook"))
 }
 
 func ListLifecycleHooks(s *session.Session) ([]Resource, error) {

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -21,11 +21,12 @@ func init() {
 	// To get an overview of available cloud control resource types run this
 	// command in the repo root:
 	//     go run ./dev/list-cloudcontrol
+	registerCloudControl("AWS::MWAA::Environment")
+	registerCloudControl("AWS::Synthetics::Canary")
 	registerCloudControl("AWS::Timestream::Database")
 	registerCloudControl("AWS::Timestream::ScheduledQuery")
 	registerCloudControl("AWS::Timestream::Table")
 	registerCloudControl("AWS::Transfer::Workflow")
-	registerCloudControl("AWS::Synthetics::Canary")
 }
 
 func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudcontrolapi"
+	"github.com/pkg/errors"
+	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	// It is required to manually define Cloud Control API targets, because
+	// existing configs that already filter old-style resources could break,
+	// because the resource is also available via Cloud Control.
+	//
+	// To get an overview of available cloud control resource types run this
+	// command in the repo root:
+	//     go run ./dev/list-cloudcontrol
+	registerCloudControl("AWS::Timestream::Database")
+	registerCloudControl("AWS::Timestream::ScheduledQuery")
+	registerCloudControl("AWS::Timestream::Table")
+}
+
+func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {
+	return func(sess *session.Session) ([]Resource, error) {
+		svc := cloudcontrolapi.New(sess)
+
+		params := &cloudcontrolapi.ListResourcesInput{
+			TypeName: aws.String(typeName),
+		}
+		resources := make([]Resource, 0)
+		err := svc.ListResourcesPages(params, func(page *cloudcontrolapi.ListResourcesOutput, lastPage bool) bool {
+			for _, desc := range page.ResourceDescriptions {
+				identifier := aws.StringValue(desc.Identifier)
+
+				propMap := map[string]interface{}{}
+				err := json.Unmarshal([]byte(aws.StringValue(desc.Properties)), &propMap)
+				if err != nil {
+					logrus.
+						WithError(errors.WithStack(err)).
+						WithField("type-name", typeName).
+						WithField("identifier", identifier).
+						Error("failed to parse cloud control properties")
+					continue
+				}
+				properties := types.NewProperties().
+					Set("Identifier", identifier)
+				for name, value := range propMap {
+					switch v := value.(type) {
+					case string:
+						properties = properties.Set(name, v)
+					default:
+						// We cannot rely on the default handling of
+						// properties.Set, because it would fall back to
+						// fmt.Sprintf. Since the cloud control properties are
+						// nested it would create properties that are not
+						// suitable for filtering. Therefore we have to
+						// implemented more sophisticated parsing.
+						logrus.
+							WithField("type-name", typeName).
+							WithField("identifier", identifier).
+							WithField("value", fmt.Sprintf("%q", v)).
+							Debugf("cloud control property type %T is not supported", v)
+					}
+				}
+
+				resources = append(resources, &CloudControlResource{
+					svc:        svc,
+					typeName:   typeName,
+					identifier: identifier,
+					properties: properties,
+				})
+			}
+
+			return true
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		return resources, nil
+	}
+}
+
+type CloudControlResource struct {
+	svc        *cloudcontrolapi.CloudControlApi
+	typeName   string
+	identifier string
+	properties types.Properties
+}
+
+func (r *CloudControlResource) String() string {
+	return r.identifier
+}
+
+func (i *CloudControlResource) Remove() error {
+	return nil
+}
+
+func (r *CloudControlResource) Properties() types.Properties {
+	return r.properties
+}

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -21,6 +21,12 @@ func init() {
 	// To get an overview of available cloud control resource types run this
 	// command in the repo root:
 	//     go run ./dev/list-cloudcontrol
+	registerCloudControl("AWS::AppFlow::ConnectorProfile")
+	registerCloudControl("AWS::AppFlow::Flow")
+	registerCloudControl("AWS::AppRunner::Service")
+	registerCloudControl("AWS::ApplicationInsights::Application")
+	registerCloudControl("AWS::Athena::DataCatalog")
+	registerCloudControl("AWS::Backup::Framework")
 	registerCloudControl("AWS::MWAA::Environment")
 	registerCloudControl("AWS::Synthetics::Canary")
 	registerCloudControl("AWS::Timestream::Database")

--- a/resources/cloudcontrol_test.go
+++ b/resources/cloudcontrol_test.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudControlParseProperties(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "ActualEC2VPC",
+			payload: `{"VpcId":"vpc-456","InstanceTenancy":"default","CidrBlockAssociations":["vpc-cidr-assoc-1234", "vpc-cidr-assoc-5678"],"CidrBlock":"10.10.0.0/16","Tags":[{"Value":"Kubernetes VPC","Key":"Name"}]}`,
+			want:    `[CidrBlock: "10.10.0.0/16", CidrBlockAssociations.["vpc-cidr-assoc-1234"]: "true", CidrBlockAssociations.["vpc-cidr-assoc-5678"]: "true", InstanceTenancy: "default", Tags.["Name"]: "Kubernetes VPC", VpcId: "vpc-456"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := cloudControlParseProperties(tc.payload)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, result.String())
+		})
+	}
+}

--- a/resources/cloudformation-stackset.go
+++ b/resources/cloudformation-stackset.go
@@ -2,18 +2,20 @@ package resources
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
 	"github.com/sirupsen/logrus"
-	"strings"
-	"time"
 )
 
 func init() {
-	register("CloudFormationStackSet", ListCloudFormationStackSets)
+	register("CloudFormationStackSet", ListCloudFormationStackSets,
+		mapCloudControl("AWS::CloudFormation::StackSet"))
 }
 
 func ListCloudFormationStackSets(sess *session.Session) ([]Resource, error) {

--- a/resources/ec2-vpc.go
+++ b/resources/ec2-vpc.go
@@ -13,7 +13,8 @@ type EC2VPC struct {
 }
 
 func init() {
-	register("EC2VPC", ListEC2VPCs)
+	register("EC2VPC", ListEC2VPCs,
+		mapCloudControl("AWS::EC2::VPC"))
 }
 
 func ListEC2VPCs(sess *session.Session) ([]Resource, error) {

--- a/resources/interface.go
+++ b/resources/interface.go
@@ -71,10 +71,6 @@ func mapCloudControl(typeName string) registerOption {
 	}
 }
 
-func GetListers() ResourceListers {
-	return resourceListers
-}
-
 func GetLister(name string) ResourceLister {
 	if strings.HasPrefix(name, "AWS::") {
 		return NewListCloudControlResource(name)
@@ -84,7 +80,7 @@ func GetLister(name string) ResourceLister {
 
 func GetListerNames() []string {
 	names := []string{}
-	for resourceType, _ := range GetListers() {
+	for resourceType := range resourceListers {
 		names = append(names, resourceType)
 	}
 

--- a/resources/prometheusservice-workspace.go
+++ b/resources/prometheusservice-workspace.go
@@ -14,7 +14,8 @@ type AMPWorkspace struct {
 }
 
 func init() {
-	register("AMPWorkspace", ListAMPWorkspaces)
+	register("AMPWorkspace", ListAMPWorkspaces,
+		mapCloudControl("AWS::APS::Workspace"))
 }
 
 func ListAMPWorkspaces(sess *session.Session) ([]Resource, error) {

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -15,7 +15,8 @@ import (
 )
 
 func init() {
-	register("S3Bucket", ListS3Buckets)
+	register("S3Bucket", ListS3Buckets,
+		mapCloudControl("AWS::S3::Bucket"))
 }
 
 type S3Bucket struct {
@@ -42,7 +43,7 @@ func ListS3Buckets(s *session.Session) ([]Resource, error) {
 			if aerr, ok := err.(awserr.Error); ok {
 				if aerr.Code() == "NoSuchTagSet" {
 					resources = append(resources, &S3Bucket{
-						svc: svc,
+						svc:  svc,
 						name: name,
 						tags: make([]*s3.Tag, 0),
 					})

--- a/resources/wafv2-ipsets.go
+++ b/resources/wafv2-ipsets.go
@@ -16,7 +16,8 @@ type WAFv2IPSet struct {
 }
 
 func init() {
-	register("WAFv2IPSet", ListWAFv2IPSets)
+	register("WAFv2IPSet", ListWAFv2IPSets,
+		mapCloudControl("AWS::WAFv2::IPSet"))
 }
 
 func ListWAFv2IPSets(sess *session.Session) ([]Resource, error) {

--- a/resources/wafv2-regex-pattern-sets.go
+++ b/resources/wafv2-regex-pattern-sets.go
@@ -16,7 +16,8 @@ type WAFv2RegexPatternSet struct {
 }
 
 func init() {
-	register("WAFv2RegexPatternSet", ListWAFv2RegexPatternSets)
+	register("WAFv2RegexPatternSet", ListWAFv2RegexPatternSets,
+		mapCloudControl("AWS::WAFv2::RegexPatternSet"))
 }
 
 func ListWAFv2RegexPatternSets(sess *session.Session) ([]Resource, error) {

--- a/resources/wafv2-rulegroup.go
+++ b/resources/wafv2-rulegroup.go
@@ -16,7 +16,8 @@ type WAFv2RuleGroup struct {
 }
 
 func init() {
-	register("WAFv2RuleGroup", ListWAFv2RuleGroups)
+	register("WAFv2RuleGroup", ListWAFv2RuleGroups,
+		mapCloudControl("AWS::WAFv2::RuleGroup"))
 }
 
 func ListWAFv2RuleGroups(sess *session.Session) ([]Resource, error) {

--- a/resources/wafv2-webacls.go
+++ b/resources/wafv2-webacls.go
@@ -16,7 +16,8 @@ type WAFv2WebACL struct {
 }
 
 func init() {
-	register("WAFv2WebACL", ListWAFv2WebACLs)
+	register("WAFv2WebACL", ListWAFv2WebACLs,
+		mapCloudControl("AWS::WAFv2::WebACL"))
 }
 
 func ListWAFv2WebACLs(sess *session.Session) ([]Resource, error) {

--- a/resources/xray-group.go
+++ b/resources/xray-group.go
@@ -13,7 +13,8 @@ type XRayGroup struct {
 }
 
 func init() {
-	register("XRayGroup", ListXRayGroups)
+	register("XRayGroup", ListXRayGroups,
+		mapCloudControl("AWS::XRay::Group"))
 }
 
 func ListXRayGroups(sess *session.Session) ([]Resource, error) {

--- a/resources/xray-group.go
+++ b/resources/xray-group.go
@@ -13,8 +13,7 @@ type XRayGroup struct {
 }
 
 func init() {
-	register("XRayGroup", ListXRayGroups,
-		mapCloudControl("AWS::XRay::Group"))
+	register("XRayGroup", ListXRayGroups)
 }
 
 func ListXRayGroups(sess *session.Session) ([]Resource, error) {

--- a/resources/xray-samplingrule.go
+++ b/resources/xray-samplingrule.go
@@ -13,7 +13,8 @@ type XRaySamplingRule struct {
 }
 
 func init() {
-	register("XRaySamplingRule", ListXRaySamplingRules)
+	register("XRaySamplingRule", ListXRaySamplingRules,
+		mapCloudControl("AWS::XRay::SamplingRule"))
 }
 
 func ListXRaySamplingRules(sess *session.Session) ([]Resource, error) {

--- a/resources/xray-samplingrule.go
+++ b/resources/xray-samplingrule.go
@@ -13,8 +13,7 @@ type XRaySamplingRule struct {
 }
 
 func init() {
-	register("XRaySamplingRule", ListXRaySamplingRules,
-		mapCloudControl("AWS::XRay::SamplingRule"))
+	register("XRaySamplingRule", ListXRaySamplingRules)
 }
 
 func ListXRaySamplingRules(sess *session.Session) ([]Resource, error) {


### PR DESCRIPTION
> Supersedes https://github.com/rebuy-de/aws-nuke/pull/737

Adds support for the Cloud Control API. Cloud Control API resources will behave like regular (now called "old-style") resources as seen in this example:

### Related Tickets:

* added resources: https://github.com/rebuy-de/aws-nuke/issues/745
* https://github.com/rebuy-de/aws-nuke/issues/692


```
eu-west-1 - AWS::EC2::VPC - vpc-08852bdafa9189b5c - [CidrBlock: "172.22.16.0/20", Identifier: "vpc-08852bdafa9189b5c", InstanceTenancy: "default", VpcId: "vpc-08852bdafa9189b5c"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.
```

---

The output of `go run go run ./dev/list-cloudcontrol` looks like this:

![image](https://user-images.githubusercontent.com/1698599/157853841-5c6b5074-3fec-422f-b9ee-2d5b906c3d6e.png)

---

### TODO

* [x] Properly handle properties (see `resources/cloudcontrol.go`). For example we need to convert `CidrBlockAssociations` and `Tags` into a format, that is usable by the filter config.
```json
{
  "VpcId": "vpc-456",
  "InstanceTenancy": "default",
  "CidrBlockAssociations": [
    "vpc-cidr-assoc-1234"
  ],
  "CidrBlock": "10.10.0.0/16",
  "Tags": [
    {
      "Value": "Kubernetes VPC",
      "Key": "Name"
    }
  ]
}
```
```
# Currently it would simply look like this:
eu-west-1 - AWS::EC2::VPC - vpc-456 - [CidrBlock: "10.10.0.0/16", CidrBlockAssociations: "[vpc-cidr-assoc-1234]", Identifier: "vpc-08852bdafa9189b5c", InstanceTenancy: "default", Tags: "[map[Key:Name Value:Kubernetes VPC]]", VpcId: "vpc-456"] - would remove
```
* [ ] ~Handle rate limiting~ I cannot reproduce the rate limit with the new approach to cloud control
* [x] Add actual removal
* [x] add documentation
* [ ] ~handle global services (eg S3) better: currently they get listed for every region~ I do not have a solution to this, yet.