### PR TITLE
added tags and other properties to iam-users

### DIFF
--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type Properties map[string]string
@@ -48,6 +49,11 @@ func (p Properties) Set(key string, value interface{}) Properties {
 			return p
 		}
 		p[key] = fmt.Sprint(*v)
+	case *time.Time:
+		if v == nil {
+			return p
+		}
+		p[key] = v.Format(time.RFC3339)
 	default:
 		// Fallback to Stringer interface. This produces gibberish on pointers,
 		// but is the only way to avoid reflection.

--- a/resources/iam-service-specific-credentials.go
+++ b/resources/iam-service-specific-credentials.go
@@ -35,7 +35,7 @@ func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
 			continue
 		}
 		params := &iam.ListServiceSpecificCredentialsInput{
-			UserName: user.user.UserName,
+			UserName: user.userName,
 		}
 		serviceCredentials, err := svc.ListServiceSpecificCredentials(params)
 		if err != nil {
@@ -48,7 +48,7 @@ func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
 				name:        *credential.ServiceUserName,
 				serviceName: *credential.ServiceName,
 				id:          *credential.ServiceSpecificCredentialId,
-				userName:    *user.user.UserName,
+				userName:    *user.userName,
 			})
 		}
 	}

--- a/resources/iam-service-specific-credentials.go
+++ b/resources/iam-service-specific-credentials.go
@@ -35,7 +35,7 @@ func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
 			continue
 		}
 		params := &iam.ListServiceSpecificCredentialsInput{
-			UserName: &user.name,
+			UserName: user.user.UserName,
 		}
 		serviceCredentials, err := svc.ListServiceSpecificCredentials(params)
 		if err != nil {
@@ -48,7 +48,7 @@ func ListServiceSpecificCredentials(sess *session.Session) ([]Resource, error) {
 				name:        *credential.ServiceUserName,
 				serviceName: *credential.ServiceName,
 				id:          *credential.ServiceSpecificCredentialId,
-				userName:    user.name,
+				userName:    *user.user.UserName,
 			})
 		}
 	}


### PR DESCRIPTION
I encountered a problem where the IAM-users couldn't be filtered according to their tags!

Looking at the code I realized that the code might have been referring to an older version of the GO-SDK.  

According to [ListUsers](https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM.ListUsers) it does not return all the user information. Specifically not the Tags.  
The docs then make reference to [GetUser](https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM.GetUser) which doesn't return all a list of users, but does return all the information regarding a user (including tags!)  

This does sadly mean that we have to do 2 requests:
1. The first where we get the list of the users with some of the data: *ARN, Name, Path, Created Date, ID and The Last Time a Password was used*
2. The second when we have to get all the User Information with *just* the UserName.  

While this sucks because we get 80% of the data and then only use 1 part of it, and then get 100% the data, **again**, I couldn't find a way around it.
Looking at the GO-SDK it doesn't look like there is a way to get all of what want at once sadly.
