### PR TITLE
fix: exclude nested cloudformation stacks

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -33,6 +33,9 @@ func ListCloudFormationStacks(sess *session.Session) ([]Resource, error) {
 			return nil, err
 		}
 		for _, stack := range resp.Stacks {
+			if aws.StringValue(stack.ParentId) != "" {
+				continue
+			}
 			resources = append(resources, &CloudFormationStack{
 				svc:               svc,
 				stack:             stack,


### PR DESCRIPTION
If a CloudFormation Stack has a ParentID then it is nested and should be excluded from the cleanup. A nest stack will be taken care of when the parent stack is cleaned up.