### PR TITLE
Add tag support for IAMUser and IAMUserPolicyAtt

### DIFF
--- a/resources/iam-users.go
+++ b/resources/iam-users.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/rebuy-de/aws-nuke/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 type IAMUser struct {
@@ -16,6 +17,14 @@ func init() {
 	register("IAMUser", ListIAMUsers)
 }
 
+func GetIAMUser(svc *iam.IAM, userName *string) (*iam.User, error) {
+	params := &iam.GetUserInput{
+		UserName: userName,
+	}
+	resp, err := svc.GetUser(params)
+	return resp.User, err
+}
+
 func ListIAMUsers(sess *session.Session) ([]Resource, error) {
 	svc := iam.New(sess)
 
@@ -26,10 +35,15 @@ func ListIAMUsers(sess *session.Session) ([]Resource, error) {
 
 	resources := make([]Resource, 0)
 	for _, out := range resp.Users {
+		user, err := GetIAMUser(svc, out.UserName)
+		if err != nil {
+			logrus.Errorf("Failed to get user %s: %v", *out.UserName, err)
+			continue
+		}
 		resources = append(resources, &IAMUser{
 			svc:  svc,
 			name: *out.UserName,
-			tags: out.Tags,
+			tags: user.Tags,
 		})
 	}
 


### PR DESCRIPTION
The tag support that was added for IAMUser wasn't working as it
was relying on the tags coming back via the UserList API. AWS
documnents that while the response includes a list of tags, it
isn't populated. Fixed this issue by calling GetUser to retrieve
the tags.

Added support for tags to IAMUserPolicyAttachments that mimics the
functionality present in IAMRolePolicyAttachments.