### PR TITLE
fix: default security group deletion

### DIFF
--- a/resources/ec2-default-security-group-rules.go
+++ b/resources/ec2-default-security-group-rules.go
@@ -43,6 +43,10 @@ func ListEC2SecurityGroupRules(sess *session.Session) ([]Resource, error) {
 		return nil, err
 	}
 
+	if len(groupIds) == 0 {
+		return resources, nil
+	}
+
 	sgRuleFilters := []*ec2.Filter{
 		{
 			Name:   aws.String("group-id"),


### PR DESCRIPTION
If it finds no security groups, it should return before trying to process otherwise it ends in an error 

```console
ERRO[0005] Listing EC2DefaultSecurityGroupRule failed:
    InvalidGroupId.Malformed: The security group ID '' is malformed
    	status code: 400, request id: 6a59e2c6-d0d0-4a14-ac31-2ed80adc6cb6
```