### PR TITLE
disable AWS::Athena::DataCatalog

### DIFF
--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -25,7 +25,6 @@ func init() {
 	registerCloudControl("AWS::AppFlow::Flow")
 	registerCloudControl("AWS::AppRunner::Service")
 	registerCloudControl("AWS::ApplicationInsights::Application")
-	registerCloudControl("AWS::Athena::DataCatalog")
 	registerCloudControl("AWS::Backup::Framework")
 	registerCloudControl("AWS::MWAA::Environment")
 	registerCloudControl("AWS::Synthetics::Canary")


### PR DESCRIPTION
aws-nuke is stuck on this resource:

```
us-east-1 - AWS::Athena::DataCatalog - AwsDataCatalog - [Identifier: "AwsDataCatalog", Name: "AwsDataCatalog", Type
: "GLUE"] - waiting                                                                                                

```