### PR TITLE
add AWS::NetworkFirewall

### DIFF
--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -32,6 +32,9 @@ func init() {
 	registerCloudControl("AWS::Timestream::ScheduledQuery")
 	registerCloudControl("AWS::Timestream::Table")
 	registerCloudControl("AWS::Transfer::Workflow")
+	registerCloudControl("AWS::NetworkFirewall::Firewall")
+	registerCloudControl("AWS::NetworkFirewall::FirewallPolicy")
+	registerCloudControl("AWS::NetworkFirewall::RuleGroup")
 }
 
 func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {


### PR DESCRIPTION
Fixes #776

Example:

```
eu-west-1 - AWS::NetworkFirewall::Firewall - arn:aws:network-firewall:eu-west-1:138758637120:firewall/test - [FirewallArn: "arn:aws:network-firewall:eu-west-1:138758637120:firewall/test", Identifier: "arn:aws:network-firewall:eu-west-1:138758637120:firewall/test"] - would remove
eu-west-1 - AWS::NetworkFirewall::FirewallPolicy - arn:aws:network-firewall:eu-west-1:138758637120:firewall-policy/test - [FirewallPolicyArn: "arn:aws:network-firewall:eu-west-1:138758637120:firewall-policy/test", FirewallPolicyName: "test", Identifier: "arn:aws:network-firewall:eu-west-1:138758637120:firewall-policy/test"] - would remove
```