### PR TITLE
Build release binary with Go 1.18

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Checkout code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Dang, missed this.