### PR TITLE
fix: Correctly filter policy attachments in aws-us-gov

### DIFF
--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -80,7 +80,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 }
 
 func (e *IAMRolePolicyAttachment) Filter() error {
-	if strings.Contains(e.policyArn, ":iam::aws:policy/aws-service-role/"){
+	if strings.Contains(e.policyArn, ":iam::aws:policy/aws-service-role/") {
 		return fmt.Errorf("cannot detach from service roles")
 	}
 	return nil

--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -80,7 +80,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 }
 
 func (e *IAMRolePolicyAttachment) Filter() error {
-	if strings.HasPrefix(e.policyArn, "arn:aws:iam::aws:policy/aws-service-role/") {
+	if strings.Contains(e.policyArn, ":iam::aws:policy/aws-service-role/"){
 		return fmt.Errorf("cannot detach from service roles")
 	}
 	return nil


### PR DESCRIPTION
In gov regins service policies have different prefix, and are formatted like `arn:aws-us-gov:iam::aws:policy/aws-service-role/AWSElasticLoadBalancingServiceRolePolicy`. Before this change running aws-nuke against gov accounts results in the following error:
```
level=error msg="UnmodifiableEntity: Cannot perform the operation on the protected role 'AWSServiceRoleForElasticLoadBalancing' - this role is only modifiable by AWS\n\tstatus code: 400
```