### PR TITLE
Remove unused type NukeParameters in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,21 +6,6 @@ import (
 	"github.com/rebuy-de/aws-nuke/v2/cmd"
 )
 
-type NukeParameters struct {
-	ConfigPath string
-
-	Profile         string
-	AccessKeyID     string
-	SecretAccessKey string
-
-	NoDryRun   bool
-	Force      bool
-	ForceSleep int
-	Quiet      bool
-
-	MaxWaitRetries int
-}
-
 func main() {
 	if err := cmd.NewRootCommand().Execute(); err != nil {
 		os.Exit(-1)


### PR DESCRIPTION
This was probably succeeded by the one in cmd/params.go