### PR TITLE
improvement: New resource EC2VPCEndpointConnection

### DIFF
--- a/resources/ec2-vpc-endpoint-connections.go
+++ b/resources/ec2-vpc-endpoint-connections.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2VPCEndpointConnection struct {
+	svc           *ec2.EC2
+	serviceID     *string
+	vpcEndpointID *string
+	state         *string
+}
+
+func init() {
+	register("EC2VPCEndpointConnection", ListEC2VPCEndpointConnections)
+}
+
+func ListEC2VPCEndpointConnections(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+	resources := make([]Resource, 0)
+	params := &ec2.DescribeVpcEndpointConnectionsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		resp, err := svc.DescribeVpcEndpointConnections(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, endpointConnection := range resp.VpcEndpointConnections {
+			resources = append(resources, &EC2VPCEndpointConnection{
+				svc:           svc,
+				vpcEndpointID: endpointConnection.VpcEndpointId,
+				serviceID:     endpointConnection.ServiceId,
+				state:         endpointConnection.VpcEndpointState,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (c *EC2VPCEndpointConnection) Filter() error {
+	if *c.state == "deleting" || *c.state == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+	return nil
+}
+
+func (c *EC2VPCEndpointConnection) Remove() error {
+	params := &ec2.RejectVpcEndpointConnectionsInput{
+		ServiceId: c.serviceID,
+		VpcEndpointIds: []*string{
+			c.vpcEndpointID,
+		},
+	}
+
+	_, err := c.svc.RejectVpcEndpointConnections(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *EC2VPCEndpointConnection) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("VpcEndpointID", c.vpcEndpointID)
+	properties.Set("State", c.state)
+	return properties
+}
+
+func (c *EC2VPCEndpointConnection) String() string {
+	return *c.serviceID
+}

--- a/resources/ec2-vpc-endpoint-connections.go
+++ b/resources/ec2-vpc-endpoint-connections.go
@@ -14,6 +14,7 @@ type EC2VPCEndpointConnection struct {
 	serviceID     *string
 	vpcEndpointID *string
 	state         *string
+	owner         *string
 }
 
 func init() {
@@ -39,6 +40,7 @@ func ListEC2VPCEndpointConnections(sess *session.Session) ([]Resource, error) {
 				vpcEndpointID: endpointConnection.VpcEndpointId,
 				serviceID:     endpointConnection.ServiceId,
 				state:         endpointConnection.VpcEndpointState,
+				owner:         endpointConnection.VpcEndpointOwner,
 			})
 		}
 
@@ -78,6 +80,7 @@ func (c *EC2VPCEndpointConnection) Properties() types.Properties {
 	properties := types.NewProperties()
 	properties.Set("VpcEndpointID", c.vpcEndpointID)
 	properties.Set("State", c.state)
+	properties.Set("Owner", c.owner)
 	return properties
 }
 


### PR DESCRIPTION
Adds new resource EC2VPCEndpointConnection to handle rejection of existing commands prior to removal of EC2VPCEndpointServiceConfiguration. See the [docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteVpcEndpointServiceConfigurations.html) for reference, especially:
```
Deletes one or more VPC endpoint service configurations in your account. Before you delete the endpoint service configuration, you must reject any Available or PendingAcceptance interface endpoint connections that are attached to the service.
```

Test output:
```
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
eu-west-1 - EC2VPCEndpointConnection - vpce-svc-$REDACTED - [Owner: "$REDACTED", State: "available", VpcEndpointID: "vpce-$REDACTED"] - would remove
Scan complete: 15 total, 15 nukeable, 0 filtered.
```
