### PR TITLE
Fixed version lock on docker command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ $ docker run \
     --rm -it \
     -v /full-path/to/nuke-config.yml:/home/aws-nuke/config.yml \
     -v /home/user/.aws:/home/aws-nuke/.aws \
-    quay.io/rebuy/aws-nuke:v2.11.0 \
+    quay.io/rebuy/aws-nuke:latest \
     --profile default \
     --config /home/aws-nuke/config.yml
 ```


### PR DESCRIPTION
While attempting to follow the example in your README, I was hitting an issue with the structure of `nuke-config.yml`.

The v2.11.0 version of `aws-nuke` was not marshalling because you now use `account-blocklist` in all of your examples, but that version only accepted the deprecated `account-blacklist`.

If we switch to running the `:latest` image, it'll work with either version of the blocklist key.