### PR TITLE
Only force sleep to be more than 3 seconds if `--no-dry-run` is set

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -33,8 +33,8 @@ func NewNuke(params NukeParameters, account awsutil.Account) *Nuke {
 func (n *Nuke) Run() error {
 	var err error
 
-	if n.Parameters.ForceSleep < 3 {
-		return fmt.Errorf("Value for --force-sleep cannot be less than 3 seconds. This is for your own protection.")
+	if n.Parameters.ForceSleep < 3 && n.Parameters.NoDryRun {
+		return fmt.Errorf("Value for --force-sleep cannot be less than 3 seconds if --no-dry-run is set. This is for your own protection.")
 	}
 	forceSleep := time.Duration(n.Parameters.ForceSleep) * time.Second
 


### PR DESCRIPTION
Useful for debugging discovery/listing. Allows setting it to 0 if the nuking isn't going to be happen.