### PR TITLE
[Feat/Addition] Add resource for EC2SpotInstanceRequest

### DIFF
--- a/resources/ec2-spot-instance-request.go
+++ b/resources/ec2-spot-instance-request.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2SpotInstanceRequest struct {
+	svc   *ec2.EC2
+	id    string
+	state string
+}
+
+func init() {
+	register("EC2SpotInstanceRequest", ListEC2SpotInstanceRequests)
+}
+
+func ListEC2SpotInstanceRequests(sess *session.Session) ([]Resource, error) {
+	svc := ec2.New(sess)
+
+	resp, err := svc.DescribeSpotInstanceRequests(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+	for _, config := range resp.SpotInstanceRequestConfigs {
+		resources = append(resources, &EC2SpotInstanceRequest{
+			svc:   svc,
+			id:    *config.SpotInstanceRequestId,
+			state: *config.SpotInstanceRequestState,
+		})
+	}
+
+	return resources, nil
+}
+
+func (i *EC2SpotInstanceRequest) Filter() error {
+	if i.state == "cancelled" {
+		return fmt.Errorf("already cancelled")
+	}
+	return nil
+}
+
+func (i *EC2SpotInstanceRequest) Remove() error {
+	params := &ec2.CancelSpotInstanceRequestsInput{
+		TerminateInstances: aws.Bool(true),
+		SpotInstanceRequestIds: []*string{
+			&i.id,
+		},
+	}
+
+	_, err := i.svc.CancelSpotInstanceRequests(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *EC2SpotInstanceRequest) String() string {
+	return i.id
+}

--- a/resources/ec2-spot-instance-request.go
+++ b/resources/ec2-spot-instance-request.go
@@ -2,15 +2,18 @@ package resources
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
 type EC2SpotInstanceRequest struct {
-	svc   *ec2.EC2
-	id    string
-	state string
+	svc                 *ec2.EC2
+	spotInstanceRequest *ec2.SpotInstanceRequest
+	id                  string
+	state               string
 }
 
 func init() {
@@ -57,6 +60,24 @@ func (i *EC2SpotInstanceRequest) Remove() error {
 	}
 
 	return nil
+}
+
+func (i *EC2SpotInstanceRequest) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("AvailabilityZoneGroup", i.spotInstanceRequest.AvailabilityZoneGroup)
+	properties.Set("InstanceId", i.spotInstanceRequest.InstanceId)
+	properties.Set("SpotInstanceRequestId", i.spotInstanceRequest.SpotInstanceRequestId)
+	properties.Set("SpotPrice", i.spotInstanceRequest.SpotPrice)
+	properties.Set("SpotPrice", i.spotInstanceRequest.SpotPrice)
+	properties.Set("SpotInstanceState", i.spotInstanceRequest.State)
+	properties.Set("LaunchTime", i.spotInstanceRequest.CreateTime.Format(time.RFC1123))
+	properties.Set("SpotInstanceType", i.spotInstanceRequest.Type)
+
+	for _, tagValue := range i.spotInstanceRequest.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+
+	return properties
 }
 
 func (i *EC2SpotInstanceRequest) String() string {

--- a/resources/ec2-spot-instance-request.go
+++ b/resources/ec2-spot-instance-request.go
@@ -27,11 +27,10 @@ func ListEC2SpotInstanceRequests(sess *session.Session) ([]Resource, error) {
 	}
 
 	resources := make([]Resource, 0)
-	for _, config := range resp.SpotInstanceRequestConfigs {
+	for _, config := range resp.SpotInstanceRequest {
 		resources = append(resources, &EC2SpotInstanceRequest{
-			svc:   svc,
-			id:    *config.SpotInstanceRequestId,
-			state: *config.SpotInstanceRequestState,
+			svc: svc,
+			id:  *config.SpotInstanceRequestId,
 		})
 	}
 

--- a/resources/ec2-spot-instance-request.go
+++ b/resources/ec2-spot-instance-request.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -46,7 +45,6 @@ func (i *EC2SpotInstanceRequest) Filter() error {
 
 func (i *EC2SpotInstanceRequest) Remove() error {
 	params := &ec2.CancelSpotInstanceRequestsInput{
-		TerminateInstances: aws.Bool(true),
 		SpotInstanceRequestIds: []*string{
 			&i.id,
 		},

--- a/resources/ec2-spot-instance-request.go
+++ b/resources/ec2-spot-instance-request.go
@@ -26,7 +26,7 @@ func ListEC2SpotInstanceRequests(sess *session.Session) ([]Resource, error) {
 	}
 
 	resources := make([]Resource, 0)
-	for _, config := range resp.SpotInstanceRequest {
+	for _, config := range resp.SpotInstanceRequests {
 		resources = append(resources, &EC2SpotInstanceRequest{
 			svc: svc,
 			id:  *config.SpotInstanceRequestId,
@@ -45,6 +45,7 @@ func (i *EC2SpotInstanceRequest) Filter() error {
 
 func (i *EC2SpotInstanceRequest) Remove() error {
 	params := &ec2.CancelSpotInstanceRequestsInput{
+		// TerminateInstances: aws.Bool(true),
 		SpotInstanceRequestIds: []*string{
 			&i.id,
 		},


### PR DESCRIPTION
First, thanks for the tool, and in advance for taking a look at this PR. 

When using this on our own infra we found that it failed to delete EC2 Spot Instance Requests, which we used for ad-hoc instances and not for fleets.

What this meant is that especially if using persistent spot types, the instances would be terminated by aws-nuke but simply restart themselves because their request was still present.

I'm not 100% sure this is how to solve this problem, so please review. Go is not my strong suite, but my basic thought was that it simply was a resource that wasn't evaluated by the application.

It passed CI and Testing here:

https://github.com/pww217/aws-nuke/runs/7694603979?check_suite_focus=true

I tried to build and test my own image but had some trouble. If that's required I can try to make it work.