### PR TITLE
Return "Unnamed job" for null-valued Comprehend analysis job names for logging purposes

### DIFF
--- a/resources/comprehend_dominant_language_detection_job.go
+++ b/resources/comprehend_dominant_language_detection_job.go
@@ -59,5 +59,9 @@ func (ce *ComprehendDominantLanguageDetectionJob) Properties() types.Properties 
 }
 
 func (ce *ComprehendDominantLanguageDetectionJob) String() string {
-	return *ce.dominantLanguageDetectionJob.JobName
+	if ce.dominantLanguageDetectionJob.JobName == nil {
+		return "Unnamed job"
+	} else {
+		return *ce.dominantLanguageDetectionJob.JobName
+	}
 }

--- a/resources/comprehend_entities_detection_job.go
+++ b/resources/comprehend_entities_detection_job.go
@@ -64,5 +64,9 @@ func (ce *ComprehendEntitiesDetectionJob) Properties() types.Properties {
 }
 
 func (ce *ComprehendEntitiesDetectionJob) String() string {
-	return *ce.entitiesDetectionJob.JobName
+	if ce.entitiesDetectionJob.JobName == nil {
+		return "Unnamed job"
+	} else {
+		return *ce.entitiesDetectionJob.JobName
+	}
 }

--- a/resources/comprehend_key_phrases_detection_job.go
+++ b/resources/comprehend_key_phrases_detection_job.go
@@ -59,5 +59,9 @@ func (ce *ComprehendKeyPhrasesDetectionJob) Properties() types.Properties {
 }
 
 func (ce *ComprehendKeyPhrasesDetectionJob) String() string {
-	return *ce.keyPhrasesDetectionJob.JobName
+	if ce.keyPhrasesDetectionJob.JobName == nil {
+		return "Unnamed job"
+	} else {
+		return *ce.keyPhrasesDetectionJob.JobName
+	}
 }

--- a/resources/comprehend_sentiment_detection_job.go
+++ b/resources/comprehend_sentiment_detection_job.go
@@ -64,5 +64,9 @@ func (ce *ComprehendSentimentDetectionJob) Properties() types.Properties {
 }
 
 func (ce *ComprehendSentimentDetectionJob) String() string {
-	return *ce.sentimentDetectionJob.JobName
+	if ce.sentimentDetectionJob.JobName == nil {
+		return "Unnamed job"
+	} else {
+		return *ce.sentimentDetectionJob.JobName
+	}
 }


### PR DESCRIPTION
This fixes issue #883.