### PR TITLE
Adding tags to the properties of IAMRoles

### DIFF
--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -15,6 +15,7 @@ type IAMRole struct {
 	role *iam.Role
 	name string
 	path string
+	tags []*iam.Tag
 }
 
 func init() {
@@ -55,6 +56,7 @@ func ListIAMRoles(sess *session.Session) ([]Resource, error) {
 				role: role,
 				name: *role.RoleName,
 				path: *role.Path,
+				tags: role.Tags,
 			})
 		}
 
@@ -86,22 +88,15 @@ func (e *IAMRole) Remove() error {
 	return nil
 }
 
-func (role *IAMRole) Properties() (types.Properties, error) {
+func (role *IAMRole) Properties() types.Properties {
 	properties := types.NewProperties()
-
-	tagsParams := &iam.ListRoleTagsInput{RoleName: role.role.RoleName}
-	tagsOutput, err := role.svc.ListRoleTags(tagsParams)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, tagValue := range tagsOutput.Tags {
+	for _, tagValue := range role.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.
 		Set("Name", role.name).
 		Set("Path", role.path)
-	return properties, nil
+	return properties
 }
 
 func (e *IAMRole) String() string {

--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -86,15 +86,22 @@ func (e *IAMRole) Remove() error {
 	return nil
 }
 
-func (role *IAMRole) Properties() types.Properties {
+func (role *IAMRole) Properties() (types.Properties, error) {
 	properties := types.NewProperties()
-	for _, tagValue := range role.role.Tags {
+
+	tagsParams := &iam.ListRoleTagsInput{RoleName: role.role.RoleName}
+	tagsOutput, err := role.svc.ListRoleTags(tagsParams)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tagValue := range tagsOutput.Tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.
 		Set("Name", role.name).
 		Set("Path", role.path)
-	return properties
+	return properties, nil
 }
 
 func (e *IAMRole) String() string {


### PR DESCRIPTION
Currently there is no functionality for filtering IAMRoles by tags. ListRoles' response doesn't contain the tags, associated to the IAMRoles (https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoles.html), however GetRole's does, so the tags can be added from the Role object of that function call. 