### PR TITLE
Fix readme update job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ github.head_ref }}
     - run: |
         sed -r -i "s/aws-nuke:v[0-9]+\.[0-9]+\.[0-9]+/aws-nuke:${GITHUB_REF#refs/tags/}/" README.md
         sed -r -i "s/aws-nuke-v[0-9]+\.[0-9]+\.[0-9]+/aws-nuke-${GITHUB_REF#refs/tags/}/" README.md


### PR DESCRIPTION
Failed because it's checking out the tag, so we need to set the ref explicitly
https://github.com/stefanzweifel/git-auto-commit-action#checkout-the-correct-branch