### PR TITLE
Fix crash when WAF/WAFRegional GetRule gives error

### DIFF
--- a/resources/waf-rules.go
+++ b/resources/waf-rules.go
@@ -32,9 +32,12 @@ func ListWAFRules(sess *session.Session) ([]Resource, error) {
 		}
 
 		for _, rule := range resp.Rules {
-			ruleResp, _ := svc.GetRule(&waf.GetRuleInput{
+			ruleResp, err := svc.GetRule(&waf.GetRuleInput{
 				RuleId: rule.RuleId,
 			})
+			if err != nil {
+				return nil, err
+			}
 			resources = append(resources, &WAFRule{
 				svc:  svc,
 				ID:   rule.RuleId,

--- a/resources/wafregional-rules.go
+++ b/resources/wafregional-rules.go
@@ -34,9 +34,12 @@ func ListWAFRegionalRules(sess *session.Session) ([]Resource, error) {
 		}
 
 		for _, rule := range resp.Rules {
-			ruleResp, _ := svc.GetRule(&waf.GetRuleInput{
+			ruleResp, err := svc.GetRule(&waf.GetRuleInput{
 				RuleId: rule.RuleId,
 			})
+			if err != nil {
+				return nil, err
+			}
 			resources = append(resources, &WAFRegionalRule{
 				svc:  svc,
 				ID:   rule.RuleId,


### PR DESCRIPTION
This fixes the below error (which could occur if AWS API rate limits are hit):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x39bc29b]
goroutine 1 [running]:
github.com/rebuy-de/aws-nuke/v2/resources.(*WAFRegionalRule).Remove(0xc0003b2ee0)
	/src/resources/wafregional-rules.go:66 +0x5b
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).HandleRemove(0x1e?, 0xc001208240)
	/src/cmd/nuke.go:273 +0x2a
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).HandleQueue(0xc0000ddb80)
	/src/cmd/nuke.go:249 +0x12a
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Run(0xc0000ddb80)
	/src/cmd/nuke.go:93 +0x653
github.com/rebuy-de/aws-nuke/v2/cmd.NewRootCommand.func2(0xc0002c5180?, {0x532f1d8?, 0x8?, 0x8?})
	/src/cmd/root.go:90 +0x5f4
github.com/spf13/cobra.(*Command).execute(0xc0002c5180, {0xc00003e0a0, 0x8, 0x8})
	/src/vendor/github.com/spf13/cobra/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002c5180)
	/src/vendor/github.com/spf13/cobra/command.go:990 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/src/vendor/github.com/spf13/cobra/command.go:918
main.main()
	/src/main.go:10 +0x1e
```
