### PR TITLE
Make stdin reader global so buffered input does not get discarded

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -9,10 +9,11 @@ import (
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
+var stdinReader = bufio.NewReader(os.Stdin)
+
 func Prompt(expect string) error {
 	fmt.Print("> ")
-	reader := bufio.NewReader(os.Stdin)
-	text, err := reader.ReadString('\n')
+	text, err := stdinReader.ReadString('\n')
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I am wanting to run aws-nuke as a clean-up step in automated end-to-end tests and encountered this issue.  When providing stdin to aws-nuke via a pipe or a file redirection, the second read from stdin fails to get the correct account alias.  This is because `bufio.ReadString('\n')` reads a chunk of data from stdin, then returns the string up to the first newline in the chunk.  In my case the chunk was larger than my account alias.  When the first call to `Prompt` returns, this buffered data in the chunk is lost and the second call to `Prompt` gets unexpected data.

Tested: I ran the updated code twice, passing in the account alias manually on the TTY and then via stdin redirection.  Both  runs succeeded as expected.