### PR TITLE
feat: add force-delete-iam-roles feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ feature-flags:
     EC2Instance: true
     CloudformationStack: true
   force-delete-lightsail-addons: true
+  force-delete-iam-roles: true
 ```
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Nuke struct {
 type FeatureFlags struct {
 	DisableDeletionProtection  DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	ForceDeleteLightsailAddOns bool                      `yaml:"force-delete-lightsail-addons"`
+	ForceDeleteIAMRoles        bool                      `yaml:"force-delete-iam-roles"`
 }
 
 type DisableDeletionProtection struct {


### PR DESCRIPTION
this is a proposal to address https://github.com/rebuy-de/aws-nuke/issues/902

The solution in a few words:
- this is a new feature flag ` force-delete-iam-roles`
- if true, the removal of a role will first trigger the list and removal of all attached policies (inline and managed), and all instance profiles

Happy to discuss it further, I have tested it on my own environment with success: the first iteration may fail because they happen too soon after the removal of the policies or instance profiles, but with the retries implemented it eventually succeeds.