### PR TITLE
feat: add IsEKSManaged property for all elbs and target groups

### DIFF
--- a/resources/eks-clusters.go
+++ b/resources/eks-clusters.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,6 +52,18 @@ func ListEKSClusters(sess *session.Session) ([]Resource, error) {
 		params.NextToken = resp.NextToken
 	}
 	return resources, nil
+}
+
+func mapEKSClusters(sess *session.Session) (map[string]bool, error) {
+	eksClusters, err := ListEKSClusters(sess)
+	if err != nil {
+		return nil, err
+	}
+	eksClustersMap := make(map[string]bool)
+	for _, cl := range eksClusters {
+		eksClustersMap[fmt.Sprintf("%v", cl)] = true
+	}
+	return eksClustersMap, nil
 }
 
 func (f *EKSCluster) Remove() error {

--- a/resources/elb-elb.go
+++ b/resources/elb-elb.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -57,7 +58,12 @@ func ListELBLoadBalancers(sess *session.Session) ([]Resource, error) {
 		for _, elbTagInfo := range tagResp.TagDescriptions {
 			var isEKSManaged bool
 			for _, tag := range elbTagInfo.Tags {
-				if *tag.Key == EKSClusterTag {
+				if strings.HasPrefix(*tag.Key, "kubernetes.io/cluster/") {
+					parts := strings.Split(*tag.Key, "/")
+					eksName := parts[len(parts)-1]
+					isEKSManaged = eksClusters[eksName]
+					break
+				} else if *tag.Key == EKSClusterTag {
 					isEKSManaged = eksClusters[*tag.Value]
 					break
 				}

--- a/resources/util.go
+++ b/resources/util.go
@@ -2,6 +2,10 @@ package resources
 
 import "github.com/aws/aws-sdk-go/aws/awserr"
 
+const (
+	EKSClusterTag = "elbv2.k8s.aws/cluster"
+)
+
 func UnPtrBool(ptr *bool, def bool) bool {
 	if ptr == nil {
 		return def


### PR DESCRIPTION
This adds a new property `IsEKSManaged` to the elb, elbv2 and target groups.  

The ALB controller automatically adds a tag `elbv2.k8s.aws/cluster` to those resources  (as per the aws-load-balancer-controller [documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#resource-tags))

Concerning the classic ELBs, they are handled as of today by the in-tree controller and not by the ALB controller. Hence the tag is different, which explains my second commit. I decided to let the other filter as well, in case the ALB controller would take over the management of the classic ELBs at some point.

I am not sure about my implementation though, because it does implicitly bring EKS things into load balancers resources (it would for example require the `eks:ListClusters` permission to someone wanting to manage load balancers only).

However this would be very useful for us: in our context we want to keep all resources deployed via the ALB controller of any EKS cluster alive. When deleting a cluster, it often happens that we have orphan resources.
I'd like to avoid hardcoding the clusters name in the nuke config, because I will 100% sure forget to add or remove a name one day :/

What do you think?