### PR TITLE
feat(iam-role): add properties to policies and instance profile

### DIFF
--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -14,8 +15,7 @@ type IAMRolePolicyAttachment struct {
 	svc        *iam.IAM
 	policyArn  string
 	policyName string
-	roleName   string
-	roleTags   []*iam.Tag
+	role       *iam.Role
 }
 
 func init() {
@@ -56,12 +56,11 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 						svc:        svc,
 						policyArn:  *pol.PolicyArn,
 						policyName: *pol.PolicyName,
-						roleName:   *role.RoleName,
-						roleTags:   role.Tags,
+						role:       role,
 					})
 				}
 
-				if *polResp.IsTruncated == false {
+				if !*polResp.IsTruncated {
 					break
 				}
 
@@ -69,7 +68,7 @@ func ListIAMRolePolicyAttachments(sess *session.Session) ([]Resource, error) {
 			}
 		}
 
-		if *roleResp.IsTruncated == false {
+		if !*roleResp.IsTruncated {
 			break
 		}
 
@@ -90,7 +89,7 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 	_, err := e.svc.DetachRolePolicy(
 		&iam.DetachRolePolicyInput{
 			PolicyArn: &e.policyArn,
-			RoleName:  &e.roleName,
+			RoleName:  e.role.RoleName,
 		})
 	if err != nil {
 		return err
@@ -101,15 +100,19 @@ func (e *IAMRolePolicyAttachment) Remove() error {
 
 func (e *IAMRolePolicyAttachment) Properties() types.Properties {
 	properties := types.NewProperties().
-		Set("RoleName", e.roleName).
+		Set("RoleName", e.role.RoleName).
+		Set("RolePath", e.role.Path).
+		Set("RoleLastUsed", getLastUsedDate(e.role, time.RFC3339)).
+		Set("RoleCreateDate", e.role.CreateDate.Format(time.RFC3339)).
 		Set("PolicyName", e.policyName).
 		Set("PolicyArn", e.policyArn)
-	for _, tag := range e.roleTags {
+
+	for _, tag := range e.role.Tags {
 		properties.SetTagWithPrefix("role", tag.Key, tag.Value)
 	}
 	return properties
 }
 
 func (e *IAMRolePolicyAttachment) String() string {
-	return fmt.Sprintf("%s -> %s", e.roleName, e.policyName)
+	return fmt.Sprintf("%s -> %s", *e.role.RoleName, e.policyName)
 }

--- a/resources/iam-role-policy.go
+++ b/resources/iam-role-policy.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -62,7 +63,7 @@ func ListIAMRolePolicies(sess *session.Session) ([]Resource, error) {
 					})
 				}
 
-				if *policies.IsTruncated == false {
+				if !*policies.IsTruncated {
 					break
 				}
 
@@ -70,7 +71,7 @@ func ListIAMRolePolicies(sess *session.Session) ([]Resource, error) {
 			}
 		}
 
-		if *roles.IsTruncated == false {
+		if !*roles.IsTruncated {
 			break
 		}
 
@@ -101,11 +102,13 @@ func (e *IAMRolePolicy) Remove() error {
 }
 
 func (e *IAMRolePolicy) Properties() types.Properties {
-	properties := types.NewProperties()
-	properties.Set("PolicyName", e.policyName)
-	properties.Set("role:RoleName", e.role.RoleName)
-	properties.Set("role:RoleID", e.role.RoleId)
-	properties.Set("role:Path", e.role.Path)
+	properties := types.NewProperties().
+		Set("PolicyName", e.policyName).
+		Set("role:RoleName", e.role.RoleName).
+		Set("role:RoleID", e.role.RoleId).
+		Set("role:Path", e.role.Path).
+		Set("role:LastUsed", getLastUsedDate(&e.role, time.RFC3339)).
+		Set("role:CreateDate", e.role.CreateDate.Format(time.RFC3339))
 
 	for _, tagValue := range e.role.Tags {
 		properties.SetTagWithPrefix("role", tagValue.Key, tagValue.Value)


### PR DESCRIPTION
This adds properties for IAM role related resources, adding information about the role itself for better filtering in the config:
- iam instance profiles
- iam role policies attachments
- iam role inline policies

I am opening a separate PR to not pollute my other PR (because I am not sure about the naming convention for these properties)

thanks :) 