### PR TITLE
Fix nil pointer deref for instance profiles

### DIFF
--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -107,7 +107,7 @@ func (e *IAMRole) String() string {
 
 func getLastUsedDate(role *iam.Role, format string) string {
 	var lastUsedDate *time.Time
-	if role.RoleLastUsed.LastUsedDate == nil {
+	if role.RoleLastUsed == nil || role.RoleLastUsed.LastUsedDate == nil {
 		lastUsedDate = role.CreateDate
 	} else {
 		lastUsedDate = role.RoleLastUsed.LastUsedDate


### PR DESCRIPTION
Unfortunately #914 introduced an issue with InstanceProfiles, when they were not used yet I guess.

```
global - IAMInstanceProfileRole - bastion -> {
  Arn: "arn:aws:iam::123456789012:role/example_role",
  AssumeRolePolicyDocument: "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22
ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D",
  CreateDate: 2023-01-17 07:00:50 +0000 UTC,
  Path: "/",
  RoleId: "AAAAAAAAAAAAAAA",
  RoleName: "example_role"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3c1cbdd]
goroutine 1 [running]:
github.com/rebuy-de/aws-nuke/v2/resources.getLastUsedDate(0xc000aaccc0?, {0x575f4e8?, 0xf?})
        /src/resources/iam-roles.go:110 +0x1d
github.com/rebuy-de/aws-nuke/v2/resources.(*IAMInstanceProfileRole).Properties(0xc0004b01c8)
        /src/resources/iam-instance-profile-roles.go:92 +0x16c
github.com/rebuy-de/aws-nuke/v2/cmd.Log(0xc00041a001?, {0x5750f49, 0x16}, {0x5e0f400, 0xc0004b01c8}, {{0xc0001391b8, 0x1, 0x1}, 0x0}, {0x57245be, ...})
        /src/cmd/log.go:57 +0x1ee
github.com/rebuy-de/aws-nuke/v2/cmd.(*Item).Print(0xc0001714a0?)
        /src/cmd/queue.go:36 +0x135
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Scan(0xc0001714a0)
        /src/cmd/nuke.go:179 +0x88b
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Run(0xc0001714a0)
        /src/cmd/nuke.go:61 +0x337
github.com/rebuy-de/aws-nuke/v2/cmd.NewRootCommand.func2(0xc00018e600?, {0x57188fb?, 0x4?, 0x4?})
        /src/cmd/root.go:90 +0x5f4
github.com/spf13/cobra.(*Command).execute(0xc00018e600, {0xc00012c010, 0x4, 0x4})
        /src/vendor/github.com/spf13/cobra/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc00018e600)
        /src/vendor/github.com/spf13/cobra/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /src/vendor/github.com/spf13/cobra/command.go:968
```