### PR TITLE
Expose ARN as properties for ELBs and TargetGroups for further usage

### DIFF
--- a/resources/elbv2-alb.go
+++ b/resources/elbv2-alb.go
@@ -121,8 +121,8 @@ func (e *ELBv2LoadBalancer) DisableProtection() error {
 
 func (e *ELBv2LoadBalancer) Properties() types.Properties {
 	properties := types.NewProperties().
-		Set("CreatedTime", e.elb.CreatedTime.Format(time.RFC3339))
-
+		Set("CreatedTime", e.elb.CreatedTime.Format(time.RFC3339)).
+		Set("ARN", e.elb.LoadBalancerArn)
 	for _, tagValue := range e.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}

--- a/resources/elbv2-targetgroup.go
+++ b/resources/elbv2-targetgroup.go
@@ -76,7 +76,8 @@ func (e *ELBv2TargetGroup) Remove() error {
 }
 
 func (e *ELBv2TargetGroup) Properties() types.Properties {
-	properties := types.NewProperties()
+	properties := types.NewProperties().
+		Set("ARN", e.tg.TargetGroupArn)
 	for _, tagValue := range e.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}


### PR DESCRIPTION
For these types of resources, the ID is the ARN, so this allows further operations on the resource.