### PR TITLE
Set tags property for CognitoUserPool, UserPoolDomain, UserPoolClient…

### DIFF
--- a/resources/cognito-userpool-clients.go
+++ b/resources/cognito-userpool-clients.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 	"github.com/sirupsen/logrus"
 )
@@ -14,6 +15,7 @@ type CognitoUserPoolClient struct {
 	id           *string
 	userPoolName *string
 	userPoolId   *string
+	userPoolArn  *string
 }
 
 func init() {
@@ -22,6 +24,15 @@ func init() {
 
 func ListCognitoUserPoolClients(sess *session.Session) ([]Resource, error) {
 	svc := cognitoidentityprovider.New(sess)
+
+	// Lookup current account ID
+	stsSvc := sts.New(sess)
+	callerID, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+	   return nil, err
+	}
+	accountId := callerID.Account
+	region := sess.Config.Region
 
 	userPools, poolErr := ListCognitoUserPools(sess)
 	if poolErr != nil {
@@ -55,6 +66,7 @@ func ListCognitoUserPoolClients(sess *session.Session) ([]Resource, error) {
 					name:         client.ClientName,
 					userPoolName: userPool.name,
 					userPoolId:   userPool.id,
+					userPoolArn:  aws.String("arn:aws:cognito-idp:" + *region + ":" + *accountId + ":userpool/" + *userPool.id),
 				})
 			}
 
@@ -80,10 +92,21 @@ func (p *CognitoUserPoolClient) Remove() error {
 }
 
 func (p *CognitoUserPoolClient) Properties() types.Properties {
+	params := &cognitoidentityprovider.ListTagsForResourceInput{
+		ResourceArn: p.userPoolArn,
+	}
+	tags, _ := p.svc.ListTagsForResource(params)
+
 	properties := types.NewProperties()
 	properties.Set("ID", p.id)
 	properties.Set("Name", p.name)
 	properties.Set("UserPoolName", p.userPoolName)
+	properties.Set("UserPoolId", p.userPoolId)
+	// Get the tags from CognitoUserPool instead because CognitoUserPoolClient
+	// doesnt support tags and could get it from main resource which is CognitoUserPoolClient
+	for tagKey, tagValue := range tags.Tags {
+		properties.SetTag(&tagKey, tagValue)
+	}
 	return properties
 }
 


### PR DESCRIPTION
…, CognitoIdentityProvider


This one sets tags for CognitoUserPool and copy those to dependent resources UserPoolDomain, UserPoolClient and CognitoIdentityProvider which doesnt support tagging.