### PR TITLE
Add ownerID as fields to a variety of ec2/vpc resources

### DIFF
--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -85,6 +85,21 @@ func (p Properties) SetTagWithPrefix(prefix string, tagKey *string, tagValue int
 	return p.Set(keyStr, tagValue)
 }
 
+func (p Properties) SetPropertyWithPrefix(prefix string, propertyKey string, propertyValue interface{}) Properties {
+	keyStr := strings.TrimSpace(propertyKey)
+	prefix = strings.TrimSpace(prefix)
+
+	if keyStr == "" {
+		return p
+	}
+
+	if prefix != "" {
+		keyStr = fmt.Sprintf("%s:%s", prefix, keyStr)
+	}
+
+	return p.Set(keyStr, propertyValue)
+}
+
 func (p Properties) Get(key string) string {
 	value, ok := p[key]
 	if !ok {

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -173,7 +173,7 @@ func TestPropertiesSetPropertiesWithPrefix(t *testing.T) {
 		{
 			name:   "empty",
 			prefix: "",
-			key:    "OwnerID"
+			key:    "OwnerID",
 			value:  aws.String("123456789012"),
 			want:   `[OwnerID: "123456789012"]`,
 		},

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -161,3 +161,41 @@ func TestPropertiesSetTagWithPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestPropertiesSetPropertiesWithPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		key    string
+		value  interface{}
+		want   string
+	}{
+		{
+			name:   "empty",
+			prefix: "",
+			key:    "OwnerID"
+			value:  aws.String("123456789012"),
+			want:   `[OwnerID: "123456789012"]`,
+		},
+		{
+			name:   "nonempty",
+			prefix: "igw",
+			key:    "OwnerID",
+			value:  aws.String("123456789012"),
+			want:   `[igw:OwnerID: "123456789012"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := types.NewProperties()
+
+			p.SetPropertyWithPrefix(tc.prefix, tc.key, tc.value)
+			have := p.String()
+
+			if tc.want != have {
+				t.Errorf("'%s' != '%s'", tc.want, have)
+			}
+		})
+	}
+}

--- a/resources/ec2-dhcp-options.go
+++ b/resources/ec2-dhcp-options.go
@@ -11,7 +11,7 @@ type EC2DHCPOption struct {
 	id         *string
 	tags       []*ec2.Tag
 	defaultVPC bool
-	ownerID *string
+	ownerID    *string
 }
 
 func init() {
@@ -38,7 +38,7 @@ func ListEC2DHCPOptions(sess *session.Session) ([]Resource, error) {
 			id:         out.DhcpOptionsId,
 			tags:       out.Tags,
 			defaultVPC: defVpcDhcpOptsId == *out.DhcpOptionsId,
-			ownerID: out.OwnerId,
+			ownerID:    out.OwnerId,
 		})
 	}
 

--- a/resources/ec2-dhcp-options.go
+++ b/resources/ec2-dhcp-options.go
@@ -11,6 +11,7 @@ type EC2DHCPOption struct {
 	id         *string
 	tags       []*ec2.Tag
 	defaultVPC bool
+	ownerID *string
 }
 
 func init() {
@@ -37,6 +38,7 @@ func ListEC2DHCPOptions(sess *session.Session) ([]Resource, error) {
 			id:         out.DhcpOptionsId,
 			tags:       out.Tags,
 			defaultVPC: defVpcDhcpOptsId == *out.DhcpOptionsId,
+			ownerID: out.OwnerId,
 		})
 	}
 
@@ -62,6 +64,7 @@ func (e *EC2DHCPOption) Properties() types.Properties {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.Set("DefaultVPC", e.defaultVPC)
+	properties.Set("OwnerID", e.ownerID)
 	return properties
 }
 

--- a/resources/ec2-internet-gateway-attachments.go
+++ b/resources/ec2-internet-gateway-attachments.go
@@ -12,8 +12,10 @@ import (
 type EC2InternetGatewayAttachment struct {
 	svc        *ec2.EC2
 	vpcId      *string
+	vpcOwnerID *string
 	vpcTags    []*ec2.Tag
 	igwId      *string
+	igwOwnerID *string
 	igwTags    []*ec2.Tag
 	defaultVPC bool
 }
@@ -50,8 +52,10 @@ func ListEC2InternetGatewayAttachments(sess *session.Session) ([]Resource, error
 			resources = append(resources, &EC2InternetGatewayAttachment{
 				svc:        svc,
 				vpcId:      vpc.VpcId,
+				vpcOwnerID: vpc.OwnerId,
 				vpcTags:    vpc.Tags,
 				igwId:      igw.InternetGatewayId,
+				igwOwnerID: igw.OwnerId,
 				igwTags:    igw.Tags,
 				defaultVPC: *vpc.IsDefault,
 			})
@@ -84,6 +88,8 @@ func (e *EC2InternetGatewayAttachment) Properties() types.Properties {
 		properties.SetTagWithPrefix("vpc", tagValue.Key, tagValue.Value)
 	}
 	properties.Set("DefaultVPC", e.defaultVPC)
+	properties.SetPropertyWithPrefix("vpc", "OwnerID", e.vpcOwnerID)
+	properties.SetPropertyWithPrefix("igw", "OwnerID", e.igwOwnerID)
 	return properties
 }
 

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -12,7 +12,7 @@ type EC2RouteTable struct {
 	svc        *ec2.EC2
 	routeTable *ec2.RouteTable
 	defaultVPC bool
-	ownerID *string
+	ownerID    *string
 }
 
 func init() {
@@ -38,7 +38,7 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 			svc:        svc,
 			routeTable: out,
 			defaultVPC: defVpcId == *out.VpcId,
-			ownerID: out.OwnerId,
+			ownerID:    out.OwnerId,
 		})
 	}
 

--- a/resources/ec2-route-tables.go
+++ b/resources/ec2-route-tables.go
@@ -10,6 +10,7 @@ type EC2RouteTable struct {
 	svc        *ec2.EC2
 	routeTable *ec2.RouteTable
 	defaultVPC bool
+	ownerID *string
 }
 
 func init() {
@@ -35,6 +36,7 @@ func ListEC2RouteTables(sess *session.Session) ([]Resource, error) {
 			svc:        svc,
 			routeTable: out,
 			defaultVPC: defVpcId == *out.VpcId,
+			ownerID: out.OwnerId,
 		})
 	}
 
@@ -60,6 +62,7 @@ func (e *EC2RouteTable) Properties() types.Properties {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}
 	properties.Set("DefaultVPC", e.defaultVPC)
+	properties.Set("OwnerID", e.ownerID)
 	return properties
 }
 


### PR DESCRIPTION
Allows users of aws-nuke to be able to exclude AWS RAM shared VPC resources from being nuked by exposing `ownerID` as a field from various VPC resources.