### PR TITLE
Add flag to disable alias requirement

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -45,16 +45,18 @@ func (n *Nuke) Run() error {
 		return err
 	}
 
-	fmt.Printf("Do you really want to nuke the account with "+
-		"the ID %s and the alias '%s'?\n", n.Account.ID(), n.Account.Alias())
-	if n.Parameters.Force {
-		fmt.Printf("Waiting %v before continuing.\n", forceSleep)
-		time.Sleep(forceSleep)
-	} else {
-		fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
-		err = Prompt(n.Account.Alias())
-		if err != nil {
-			return err
+	if !n.Config.FeatureFlags.DeleteAccountsWithoutAlias {
+		fmt.Printf("Do you really want to nuke the account with "+
+			"the ID %s and the alias '%s'?\n", n.Account.ID(), n.Account.Alias())
+		if n.Parameters.Force {
+			fmt.Printf("Waiting %v before continuing.\n", forceSleep)
+			time.Sleep(forceSleep)
+		} else {
+			fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
+			err = Prompt(n.Account.Alias())
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -190,7 +192,6 @@ func (n *Nuke) Scan() error {
 }
 
 func (n *Nuke) Filter(item *Item) error {
-
 	checker, ok := item.Resource.(resources.Filter)
 	if ok {
 		err := checker.Filter()
@@ -260,7 +261,6 @@ func (n *Nuke) HandleQueue() {
 			n.HandleWait(item, listCache)
 			item.Print()
 		}
-
 	}
 
 	fmt.Println()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func NewRootCommand() *cobra.Command {
 			}
 		}
 
-		account, err := awsutil.NewAccount(creds, config.CustomEndpoints)
+		account, err := awsutil.NewAccount(creds, config.CustomEndpoints, !config.FeatureFlags.DeleteAccountsWithoutAlias)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Nuke struct {
 type FeatureFlags struct {
 	DisableDeletionProtection  DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	ForceDeleteLightsailAddOns bool                      `yaml:"force-delete-lightsail-addons"`
+	DeleteAccountsWithoutAlias bool                      `yaml:"delete-accounts-without-alias"`
 }
 
 type DisableDeletionProtection struct {
@@ -102,7 +103,7 @@ func (c *Nuke) ResolveBlocklist() []string {
 }
 
 func (c *Nuke) HasBlocklist() bool {
-	var blocklist = c.ResolveBlocklist()
+	blocklist := c.ResolveBlocklist()
 	return blocklist != nil && len(blocklist) > 0
 }
 
@@ -128,16 +129,18 @@ func (c *Nuke) ValidateAccount(accountID string, aliases []string) error {
 			"but it is blocklisted. Aborting.", accountID)
 	}
 
-	if len(aliases) == 0 {
-		return fmt.Errorf("The specified account doesn't have an alias. " +
-			"For safety reasons you need to specify an account alias. " +
-			"Your production account should contain the term 'prod'.")
-	}
+	if !c.FeatureFlags.DeleteAccountsWithoutAlias {
+		if len(aliases) == 0 {
+			return fmt.Errorf("The specified account doesn't have an alias. " +
+				"For safety reasons you need to specify an account alias. " +
+				"Your production account should contain the term 'prod'.")
+		}
 
-	for _, alias := range aliases {
-		if strings.Contains(strings.ToLower(alias), "prod") {
-			return fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
-				"but it has the substring 'prod' in it. Aborting.", alias)
+		for _, alias := range aliases {
+			if strings.Contains(strings.ToLower(alias), "prod") {
+				return fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
+					"but it has the substring 'prod' in it. Aborting.", alias)
+			}
 		}
 	}
 


### PR DESCRIPTION
The requirement for an alias is arbitrary. There are many use cases where an alias is not able to be added to an account, or is pointless to do so. An example where it is a pointless requirement is when creating transient AWS sandbox accounts for development use, which must be destroyed.

The MIT license which this library is offered under, states that the library is offered as-is, with no warranties. 

This PR adds a feature flag which can be added to the `config.yaml` (`delete-accounts-without-alias`) which skips the checks for an alias when deleting accounts.

For anyone who wishes to use this feature flag for testing, you can install the fork by cloning github.com/stefanmcshane/aws-nuke, checking out `disable-alias` and running `go install`

Fixes #971