### PR TITLE
Disable EC2 Instance Stop Protection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ type Nuke struct {
 
 type FeatureFlags struct {
 	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
-	DisableEC2InstanceStopProtection bool                      `yaml:"DisableEC2InstanceStopProtection"`
+	DisableEC2InstanceStopProtection bool                      `yaml:"disable-ec2-instance-stop-protection"`
 	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,8 +37,9 @@ type Nuke struct {
 }
 
 type FeatureFlags struct {
-	DisableDeletionProtection  DisableDeletionProtection `yaml:"disable-deletion-protection"`
-	ForceDeleteLightsailAddOns bool                      `yaml:"force-delete-lightsail-addons"`
+	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
+	DisableEC2InstanceStopProtection bool                      `yaml:"DisableEC2InstanceStopProtection"`
+	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
 }
 
 type DisableDeletionProtection struct {


### PR DESCRIPTION
AWS [recently launched](https://aws.amazon.com/about-aws/whats-new/2022/05/amazon-ec2-enables-protect-instances-unintentional-stop-actions/) the ability to enable "stop protection" on EC2 instance, similar to the existing "termination protection"

This PR implemented an error-state routine to disable stop protection and retry termination.

**Open Question:** A new feature flag was added called `DisableEC2InstanceStopProtection` at the top level since this doesn't exactly fit under the `DisableDeletionProtection` hierarchy. I'd considered adding this flag under that group and just calling it something like `EC2InstanceStop` to differentiate it, but I felt that might be confusing. Thoughts?

I went back and forth on how to handle the retry-routines from two possible error states, but what I came up with works and I tried to document it inline with some comments.

# Testing

Create a set of EC2 instances with the following script:
```bash
# Get default VPC ID
echo "getting default VPC ID"
VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)

# Get default AWS Security Group ID as a comma separated string
echo "getting default security group"
SEC_GROUP_ID=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values=$VPC_ID --query 'SecurityGroups[0].GroupId' --output text | tr '\t' ',')

# Launch an EC2 instance
echo "launching EC2 instance"
INSTANCE_ID=$(aws ec2 run-instances --image-id ami-09d3b3274b6c5d4aa --count 1 --instance-type t2.micro --security-group-ids $SEC_GROUP_ID --query 'Instances[0].InstanceId' --output text)

# Enable termination protection
echo "enabling termination protection"
aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --disable-api-termination

# Launch an EC2 instance
echo "launching EC2 instance"
INSTANCE_ID=$(aws ec2 run-instances --image-id ami-09d3b3274b6c5d4aa --count 1 --instance-type t2.micro --security-group-ids $SEC_GROUP_ID --query 'Instances[0].InstanceId' --output text)

# Enable stop protection
echo "enabling stop protection"
aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --disable-api-stop

# Launch an EC2 instance
echo "launching EC2 instance"
INSTANCE_ID=$(aws ec2 run-instances --image-id ami-09d3b3274b6c5d4aa --count 1 --instance-type t2.micro --security-group-ids $SEC_GROUP_ID --query 'Instances[0].InstanceId' --output text)

# Enable termination and stop protection
echo "enabling termination and stop protection"
aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --disable-api-termination
aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --disable-api-stop
```

Running AWS Nuke with `EC2Instance` enabled successfully terminates all instances.