### PR TITLE
postponed S3 bucket removal

### DIFF
--- a/cmd/params.go
+++ b/cmd/params.go
@@ -16,6 +16,7 @@ type NukeParameters struct {
 	Force      bool
 	ForceSleep int
 	Quiet      bool
+	Period     string
 
 	MaxWaitRetries int
 }

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -16,6 +16,7 @@ const (
 	ItemStateFailed
 	ItemStateFiltered
 	ItemStateFinished
+	ItemStatePostponed
 )
 
 // An Item describes an actual AWS resource entity with the current state and
@@ -44,6 +45,8 @@ func (i *Item) Print() {
 		Log(i.Region, i.Type, i.Resource, ReasonSkip, i.Reason)
 	case ItemStateFinished:
 		Log(i.Region, i.Type, i.Resource, ReasonSuccess, "removed")
+	case ItemStatePostponed:
+		Log(i.Region, i.Type, i.Resource, ReasonWaitPending, "configured for a later removal")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,6 +161,9 @@ func NewRootCommand() *cobra.Command {
 	command.PersistentFlags().BoolVarP(
 		&params.Quiet, "quiet", "q", false,
 		"Don't show filtered resources.")
+	command.PersistentFlags().StringVarP(
+		&params.Period, "period", "p", "5s",
+		"Period of loop iteration.")
 
 	command.AddCommand(NewVersionCommand())
 	command.AddCommand(NewResourceTypesCommand())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,14 +54,14 @@ type FeatureFlags struct {
 	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	DisableEC2InstanceStopProtection bool                      `yaml:"disable-ec2-instance-stop-protection"`
 	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
-	PrepareOnlyIf                    PrepareOnlyIf             `yaml:"prepare-only-if"`
+	PostponeIf                       PostponeIf                `yaml:"postpone-if"`
 }
 
-type PrepareOnlyIf struct {
-	S3Bucket S3BucketPrepareOnlyIf `yaml:"S3Bucket"`
+type PostponeIf struct {
+	S3Bucket S3BucketPostponeIf `yaml:"S3Bucket"`
 }
 
-type S3BucketPrepareOnlyIf struct {
+type S3BucketPostponeIf struct {
 	ObjectsThreshold int `yaml:"objects-threshold"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,20 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type ItemPostponedError struct {
+	msg string
+}
+
+func NewItemPostponedError(msg string) *ItemPostponedError {
+	return &ItemPostponedError{
+		msg: msg,
+	}
+}
+
+func (e *ItemPostponedError) Error() string {
+	return e.msg
+}
+
 type ResourceTypes struct {
 	Targets      types.Collection `yaml:"targets"`
 	Excludes     types.Collection `yaml:"excludes"`
@@ -40,6 +54,15 @@ type FeatureFlags struct {
 	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	DisableEC2InstanceStopProtection bool                      `yaml:"disable-ec2-instance-stop-protection"`
 	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
+	PrepareOnlyIf                    PrepareOnlyIf             `yaml:"prepare-only-if"`
+}
+
+type PrepareOnlyIf struct {
+	S3Bucket S3BucketPrepareOnlyIf `yaml:"S3Bucket"`
+}
+
+type S3BucketPrepareOnlyIf struct {
+	ObjectsThreshold int `yaml:"objects-threshold"`
 }
 
 type DisableDeletionProtection struct {

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -93,7 +93,7 @@ func DescribeS3Buckets(svc *s3.S3) ([]s3.Bucket, error) {
 }
 
 func (e *S3Bucket) Remove() error {
-	objectsThreshold := e.featureFlags.PrepareOnlyIf.S3Bucket.ObjectsThreshold
+	objectsThreshold := e.featureFlags.PostponeIf.S3Bucket.ObjectsThreshold
 	_, err := e.svc.DeleteBucketPolicy(&s3.DeleteBucketPolicyInput{
 		Bucket: &e.name,
 	})

--- a/resources/s3-buckets.go
+++ b/resources/s3-buckets.go
@@ -173,7 +173,6 @@ func (e *S3Bucket) Remove() error {
 		})
 		return err
 	}
-	return nil
 }
 
 func (e *S3Bucket) RemoveAllVersions() error {


### PR DESCRIPTION
Hi all! Thanks a lot for this project!
I've met a problem, when was trying to run aws-nuke for S3 bucket. It takes too much time to drop all objects.
In this MR I've added `postponed` state. For this purpose I've added `postponed-if` feature for S3Bucket only at the moment. It provides a parameter called `objects-threshold` which is being used for condition checks if it's easier to delete all objects and bucket or postpone it's removal and set lifecycle configuration only.