### PR TITLE
Support for TGW Attachment Peering resources

### DIFF
--- a/resources/ec2-tgw-attachments.go
+++ b/resources/ec2-tgw-attachments.go
@@ -52,6 +52,21 @@ func (e *EC2TGWAttachment) Remove() error {
 		// as part of TGW to delete VPN attachments.
 		return fmt.Errorf("VPN attachment")
 	}
+
+	// Execute different API calls depending on the resource type.
+	if *e.tgwa.ResourceType == "peering" {
+		params := &ec2.DeleteTransitGatewayPeeringAttachmentInput{
+			TransitGatewayAttachmentId: e.tgwa.TransitGatewayAttachmentId,
+		}
+
+		_, err := e.svc.DeleteTransitGatewayPeeringAttachment(params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	params := &ec2.DeleteTransitGatewayVpcAttachmentInput{
 		TransitGatewayAttachmentId: e.tgwa.TransitGatewayAttachmentId,
 	}


### PR DESCRIPTION
Hello!

This PR is for adding support to remove TGW Attachment Peering resources, as for now only VPC attachments are supported.

I thought about creating a couple of functions, one for "VPC" resources, and another for "Peering", but I didn't wanted to touch too many code unless it is strictly required.

If you want me to perform more changes please let me know.

Thanks!

## Evidence

Before this change, any Nuke execution failed when trying to remove a TGW Attachment "peering" resource using the VPC removal API:

```
$ dist/aws-nuke -c <redacted>/aws-nuke/_ci/build/aws-nuke/config.yml --force-sleep 3 -t EC2TGWAttachment --max-wait-retries 10 -q --no-dry-run

aws-nuke version 58736c8 - Tue May  9 16:01:56 CEST 2023 - 58736c8eb2778a345bc28fc0735a492550abab79

Do you really want to nuke the account with the ID <redacted> and the alias 'default'?
Waiting 3s before continuing.
eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - would remove
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - would remove
Scan complete: 12 total, 2 nukeable, 10 filtered.

Do you really want to nuke these resources on the account with the ID <redacted> and the alias 'default'?
Waiting 3s before continuing.
eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - failed
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - failed

Removal requested: 0 waiting, 2 failed, 10 skipped, 0 finished

eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - failed
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - failed

Removal requested: 0 waiting, 2 failed, 10 skipped, 0 finished
```

After this change, it works as expected, and the resources are being deleted 🎉 

```
$ dist/aws-nuke -c <redacted>/aws-nuke/_ci/build/aws-nuke/config.yml --force --force-sleep 3 -t EC2TGWAttachment --max-wait-retries 10 -q --no-dry-run
aws-nuke version 58736c8.dirty - Tue May  9 16:12:06 CEST 2023 - 58736c8eb2778a345bc28fc0735a492550abab79

Do you really want to nuke the account with the ID <redacted> and the alias 'default'?
Waiting 3s before continuing.
eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - would remove
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - would remove
Scan complete: 12 total, 2 nukeable, 10 filtered.

Do you really want to nuke these resources on the account with the ID <redacted> and the alias 'default'?
Waiting 3s before continuing.
eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - triggered remove
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - triggered remove

Removal requested: 2 waiting, 0 failed, 10 skipped, 0 finished

eu-central-1 - EC2TGWAttachment - tgw-attach-061234563367abcde(peering) - [ID: "tgw-attach-061234563367abcde"] - waiting
eu-central-1 - EC2TGWAttachment - tgw-attach-071234567890efghi(peering) - [ID: "tgw-attach-071234567890efghi"] - waiting

Removal requested: 2 waiting, 0 failed, 10 skipped, 0 finished
```