### PR TITLE
Disabling Remediation Configuration before deleting config rule

### DIFF
--- a/resources/configservice-configrules.go
+++ b/resources/configservice-configrules.go
@@ -44,6 +44,9 @@ func ListConfigServiceConfigRules(sess *session.Session) ([]Resource, error) {
 }
 
 func (f *ConfigServiceConfigRule) Remove() error {
+	f.svc.DeleteRemediationConfiguration(&configservice.DeleteRemediationConfigurationInput{
+		ConfigRuleName: f.configRuleName,
+	})
 
 	_, err := f.svc.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
 		ConfigRuleName: f.configRuleName,


### PR DESCRIPTION
Fixes the Error:  ```"ResourceInUseException: The rule{RULE_NAME} currently has a RemediationConfiguration. Please delete the RemediationConfiguration and try again."```
