### PR TITLE
Filter IAM roles and policy attachments related to SSO

### DIFF
--- a/resources/iam-role-policy-attachments.go
+++ b/resources/iam-role-policy-attachments.go
@@ -82,6 +82,9 @@ func (e *IAMRolePolicyAttachment) Filter() error {
 	if strings.Contains(e.policyArn, ":iam::aws:policy/aws-service-role/") {
 		return fmt.Errorf("cannot detach from service roles")
 	}
+	if strings.HasPrefix(*e.role.Path, "/aws-reserved/sso.amazonaws.com/") {
+		return fmt.Errorf("cannot detach from SSO roles")
+	}
 	return nil
 }
 

--- a/resources/iam-roles.go
+++ b/resources/iam-roles.go
@@ -73,6 +73,9 @@ func (e *IAMRole) Filter() error {
 	if strings.HasPrefix(e.path, "/aws-service-role/") {
 		return fmt.Errorf("cannot delete service roles")
 	}
+	if strings.HasPrefix(e.path, "/aws-reserved/sso.amazonaws.com/") {
+		return fmt.Errorf("cannot delete SSO roles")
+	}
 	return nil
 }
 


### PR DESCRIPTION
SSO roles cannot be modified by user which resulted in errors during nuke:
```
global - IAMRole - AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546 - [CreateDate: "2023-06-20T08:01:29Z", LastUsedDate: "2023-06-20T08:01:29Z", Name: "AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546", Path: "/aws-reserved/sso.amazonaws.com/"] - failed
ERRO[0117] UnmodifiableEntity: Cannot perform the operation on the protected role 'AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546' - this role is only modifiable by AWS
	status code: 400, request id: 0d2c8792-37de-4028-8dbc-bdc6a917a861
global - IAMRolePolicyAttachment - AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546 -> AdministratorAccess - [PolicyArn: "arn:aws:iam::aws:policy/AdministratorAccess", PolicyName: "AdministratorAccess", RoleCreateDate: "2023-06-20T08:01:29Z", RoleLastUsed: "2023-06-20T08:01:29Z", RoleName: "AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546", RolePath: "/aws-reserved/sso.amazonaws.com/"] - failed
ERRO[0117] UnmodifiableEntity: Cannot perform the operation on the protected role 'AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546' - this role is only modifiable by AWS
	status code: 400, request id: c517c2b4-b4a4-43d7-a47b-6066c92aace6
```

Output after changes:
```
global - IAMRole - AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546 - [CreateDate: "2023-06-20T08:01:29Z", LastUsedDate: "2023-06-20T08:01:29Z", Name: "AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546", Path: "/aws-reserved/sso.amazonaws.com/"] - cannot delete SSO roles
global - IAMRolePolicyAttachment - AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546 -> AdministratorAccess - [PolicyArn: "arn:aws:iam::aws:policy/AdministratorAccess", PolicyName: "AdministratorAccess", RoleCreateDate: "2023-06-20T08:01:29Z", RoleLastUsed: "2023-06-20T08:01:29Z", RoleName: "AWSReservedSSO_AdministratorAccess_073ae2cbd6a6a546", RolePath: "/aws-reserved/sso.amazonaws.com/"] - cannot detach from SSO roles
```