### PR TITLE
Enable aws-cn by setting the default partition correctly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,8 @@ func NewRootCommand() *cobra.Command {
 				awsutil.DefaultAWSPartitionID = endpoints.AwsPartitionID
 			case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
 				awsutil.DefaultAWSPartitionID = endpoints.AwsUsGovPartitionID
+			case endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID:
+				awsutil.DefaultAWSPartitionID = endpoints.AwsCnPartitionID
 			default:
 				if config.CustomEndpoints.GetRegion(defaultRegion) == nil {
 					err = fmt.Errorf("The custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)


### PR DESCRIPTION
A leftover for https://github.com/rebuy-de/aws-nuke/pull/647 to support aws-cn.

Also close https://github.com/rebuy-de/aws-nuke/issues/411