### PR TITLE
kms-keys: Skip keys already in pending replica deletion state

### DIFF
--- a/resources/kms-keys.go
+++ b/resources/kms-keys.go
@@ -44,6 +44,10 @@ func ListKMSKeys(sess *session.Session) ([]Resource, error) {
 				continue
 			}
 
+			if *resp.KeyMetadata.KeyState == kms.KeyStatePendingReplicaDeletion {
+				continue
+			}
+
 			kmsKey := &KMSKey{
 				svc:     svc,
 				id:      *resp.KeyMetadata.KeyId,

--- a/resources/kms-keys.go
+++ b/resources/kms-keys.go
@@ -44,10 +44,6 @@ func ListKMSKeys(sess *session.Session) ([]Resource, error) {
 				continue
 			}
 
-			if *resp.KeyMetadata.KeyState == kms.KeyStatePendingReplicaDeletion {
-				continue
-			}
-
 			kmsKey := &KMSKey{
 				svc:     svc,
 				id:      *resp.KeyMetadata.KeyId,
@@ -88,6 +84,10 @@ func ListKMSKeys(sess *session.Session) ([]Resource, error) {
 func (e *KMSKey) Filter() error {
 	if e.state == "PendingDeletion" {
 		return fmt.Errorf("is already in PendingDeletion state")
+	}
+
+	if e.state == "PendingReplicaDeletion" {
+		return fmt.Errorf("is already in PendingReplicaDeletion state")
 	}
 
 	if e.manager != nil && *e.manager == kms.KeyManagerTypeAws {


### PR DESCRIPTION
Multi-region KMS keys enter state PendingReplicaDeletion when deleted, they should be filtered out.