### PR TITLE
Add support for CloudFront public keys and CloudFront key groups (#873)

### DIFF
--- a/resources/cloudfront-key-groups.go
+++ b/resources/cloudfront-key-groups.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontKeyGroup struct {
+	svc              *cloudfront.CloudFront
+	ID               *string
+	name             *string
+	lastModifiedTime *time.Time
+}
+
+func init() {
+	register("CloudFrontKeyGroup", ListCloudFrontKeyGroups)
+}
+
+func ListCloudFrontKeyGroups(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListKeyGroupsInput{}
+
+	for {
+		resp, err := svc.ListKeyGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.KeyGroupList.Items {
+			resources = append(resources, &CloudFrontKeyGroup{
+				svc:              svc,
+				ID:               item.KeyGroup.Id,
+				name:             item.KeyGroup.KeyGroupConfig.Name,
+				lastModifiedTime: item.KeyGroup.LastModifiedTime,
+			})
+		}
+
+		if resp.KeyGroupList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.KeyGroupList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontKeyGroup) Remove() error {
+	resp, err := f.svc.GetKeyGroup(&cloudfront.GetKeyGroupInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteKeyGroup(&cloudfront.DeleteKeyGroupInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontKeyGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	properties.Set("Name", f.name)
+	properties.Set("LastModifiedTime", f.lastModifiedTime.Format(time.RFC3339))
+	return properties
+}

--- a/resources/cloudfront-public-keys.go
+++ b/resources/cloudfront-public-keys.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontPublicKey struct {
+	svc         *cloudfront.CloudFront
+	ID          *string
+	name        *string
+	createdTime *time.Time
+}
+
+func init() {
+	register("CloudFrontPublicKey", ListCloudFrontPublicKeys)
+}
+
+func ListCloudFrontPublicKeys(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListPublicKeysInput{}
+
+	for {
+		resp, err := svc.ListPublicKeys(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.PublicKeyList.Items {
+			resources = append(resources, &CloudFrontPublicKey{
+				svc:         svc,
+				ID:          item.Id,
+				name:        item.Name,
+				createdTime: item.CreatedTime,
+			})
+		}
+
+		if resp.PublicKeyList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.PublicKeyList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontPublicKey) Remove() error {
+	resp, err := f.svc.GetPublicKey(&cloudfront.GetPublicKeyInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeletePublicKey(&cloudfront.DeletePublicKeyInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontPublicKey) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	properties.Set("Name", f.name)
+	properties.Set("CreatedTime", f.createdTime.Format(time.RFC3339))
+	return properties
+}


### PR DESCRIPTION
This closes #873 

**Output with feature activated**

```
global - CloudFrontKeyGroup - [ID: "666e78f3-yyyy-aaa-bbb-xxxxxxxx"] - would remove
global - CloudFrontPublicKey - [ID: "K3yyyyyy"] - would remove
Scan complete: 2 total, 2 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID 12346789012 and the alias 'test'?
Do you want to continue? Enter account alias to continue.
> test

global - CloudFrontKeyGroup - [ID: "666e78f3-yyyy-aaa-bbb-xxxxxxxx"] - triggered remove
global - CloudFrontPublicKey - [ID: "K3yyyyyy"] - triggered remove

Removal requested: 2 waiting, 0 failed, 0 skipped, 0 finished

global - CloudFrontKeyGroup - [ID: "666e78f3-yyyy-aaa-bbb-xxxxxxxx"] - waiting
global - CloudFrontPublicKey - [ID: "K3yyyyyy"] - waiting

Removal requested: 2 waiting, 0 failed, 0 skipped, 0 finished

global - CloudFrontKeyGroup - [ID: "666e78f3-yyyy-aaa-bbb-xxxxxxxx"] - removed
global - CloudFrontPublicKey - [ID: "K3yyyyyy"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 2 finished

Nuke complete: 0 failed, 0 skipped, 2 finished.
```
