### PR TITLE
Add opensearch packages vpc endpoint support

### DIFF
--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -1,14 +1,18 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
 type OSPackage struct {
-	svc       *opensearchservice.OpenSearchService
-	packageID *string
+	svc         *opensearchservice.OpenSearchService
+	packageID   *string
+	packageName *string
+	createdTime *time.Time
 }
 
 func init() {
@@ -27,8 +31,10 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 
 	for _, pkg := range listResp.PackageDetailsList {
 		resources = append(resources, &OSPackage{
-			svc:       svc,
-			packageID: pkg.PackageID,
+			svc:         svc,
+			packageID:   pkg.PackageID,
+			packageName: pkg.PackageName,
+			createdTime: pkg.CreatedAt,
 		})
 	}
 
@@ -45,6 +51,9 @@ func (o *OSPackage) Remove() error {
 
 func (o *OSPackage) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("PackageID", o.packageID)
+	properties.Set("PackageName", o.packageName)
+	properties.Set("CreatedTime", o.createdTime.Format(time.RFC3339))
 	return properties
 }
 

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -1,0 +1,64 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type OSPackage struct {
+	svc        *opensearchservice.OpenSearchService
+	domainName *string
+	packageID  *string
+}
+
+func init() {
+	register("OSPackage", ListOSPackages)
+}
+
+func ListOSPackages(sess *session.Session) ([]Resource, error) {
+	svc := opensearchservice.New(sess)
+
+	listResp, err := svc.DescribePackages(&opensearchservice.DescribePackagesInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+
+	for _, pkg := range listResp.PackageDetailsList {
+		domainResp, err := svc.ListDomainsForPackage(&opensearchservice.ListDomainsForPackageInput{
+			PackageID: pkg.PackageID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, domain := range domainResp.DomainPackageDetailsList {
+			resources = append(resources, &OSPackage{
+				svc:        svc,
+				domainName: domain.DomainName,
+				packageID:  pkg.PackageID,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (o *OSPackage) Remove() error {
+	_, err := o.svc.DeletePackage(&opensearchservice.DeletePackageInput{
+		PackageID: o.packageID,
+	})
+
+	return err
+}
+
+func (o *OSPackage) Properties() types.Properties {
+	properties := types.NewProperties()
+	return properties
+}
+
+func (o *OSPackage) String() string {
+	return *o.packageID
+}

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -7,9 +7,8 @@ import (
 )
 
 type OSPackage struct {
-	svc        *opensearchservice.OpenSearchService
-	domainName *string
-	packageID  *string
+	svc       *opensearchservice.OpenSearchService
+	packageID *string
 }
 
 func init() {

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -27,20 +27,10 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 
 	for _, pkg := range listResp.PackageDetailsList {
-		domainResp, err := svc.ListDomainsForPackage(&opensearchservice.ListDomainsForPackageInput{
-			PackageID: pkg.PackageID,
+		resources = append(resources, &OSPackage{
+			svc:       svc,
+			packageID: pkg.PackageID,
 		})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, domain := range domainResp.DomainPackageDetailsList {
-			resources = append(resources, &OSPackage{
-				svc:        svc,
-				domainName: domain.DomainName,
-				packageID:  pkg.PackageID,
-			})
-		}
 	}
 
 	return resources, nil

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -23,19 +23,12 @@ func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 		return nil, err
 	}
 
-	listResp, err := svc.DescribeVpcEndpoints(&opensearchservice.DescribeVpcEndpointsInput{
-		VpcEndpointIds: vpcEndpointIds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	resources := make([]Resource, 0)
 
-	for _, vpcEndpoint := range listResp.VpcEndpoints {
+	for _, vpcEndpointId := range vpcEndpointIds {
 		resources = append(resources, &OSVPCEndpoint{
 			svc:           svc,
-			vpcEndpointId: vpcEndpoint.VpcEndpointId,
+			vpcEndpointId: vpcEndpointId,
 		})
 	}
 

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -18,36 +18,21 @@ func init() {
 func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 	svc := opensearchservice.New(sess)
 
-	vpcEndpointIds, err := getOpenSearchVpcEndpointIds(svc)
+	listResp, err := svc.ListVpcEndpoints(&opensearchservice.ListVpcEndpointsInput{})
 	if err != nil {
 		return nil, err
 	}
 
 	resources := make([]Resource, 0)
 
-	for _, vpcEndpointId := range vpcEndpointIds {
+	for _, vpcEndpoint := range listResp.VpcEndpointSummaryList {
 		resources = append(resources, &OSVPCEndpoint{
 			svc:           svc,
-			vpcEndpointId: vpcEndpointId,
+			vpcEndpointId: vpcEndpoint.VpcEndpointId,
 		})
 	}
 
 	return resources, nil
-}
-
-func getOpenSearchVpcEndpointIds(svc *opensearchservice.OpenSearchService) ([]*string, error) {
-	vpcEndpointIds := make([]*string, 0)
-
-	listResp, err := svc.ListVpcEndpoints(&opensearchservice.ListVpcEndpointsInput{})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, vpcEndpoint := range listResp.VpcEndpointSummaryList {
-		vpcEndpointIds = append(vpcEndpointIds, vpcEndpoint.VpcEndpointId)
-	}
-
-	return vpcEndpointIds, nil
 }
 
 func (o *OSVPCEndpoint) Remove() error {

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -67,6 +67,7 @@ func (o *OSVPCEndpoint) Remove() error {
 
 func (o *OSVPCEndpoint) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("VpcEndpointId", o.vpcEndpointId)
 	return properties
 }
 

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type OSVPCEndpoint struct {
+	svc           *opensearchservice.OpenSearchService
+	vpcEndpointId *string
+}
+
+func init() {
+	register("OSVPCEndpoint", ListOSVPCEndpoints)
+}
+
+func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
+	svc := opensearchservice.New(sess)
+
+	listResp, err := svc.DescribeVpcEndpoints(&opensearchservice.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []*string{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+
+	for _, vpcEndpoint := range listResp.VpcEndpoints {
+		resources = append(resources, &OSVPCEndpoint{
+			svc:           svc,
+			vpcEndpointId: vpcEndpoint.VpcEndpointId,
+		})
+	}
+
+	return resources, nil
+}
+
+func (o *OSVPCEndpoint) Remove() error {
+	_, err := o.svc.DeleteVpcEndpoint(&opensearchservice.DeleteVpcEndpointInput{
+		VpcEndpointId: o.vpcEndpointId,
+	})
+
+	return err
+}
+
+func (o *OSVPCEndpoint) Properties() types.Properties {
+	properties := types.NewProperties()
+	return properties
+}
+
+func (o *OSVPCEndpoint) String() string {
+	return *o.vpcEndpointId
+}

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -18,8 +18,13 @@ func init() {
 func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 	svc := opensearchservice.New(sess)
 
+	vpcEndpointIds, err := getOpenSearchVpcEndpointIds(svc)
+	if err != nil {
+		return nil, err
+	}
+
 	listResp, err := svc.DescribeVpcEndpoints(&opensearchservice.DescribeVpcEndpointsInput{
-		VpcEndpointIds: []*string{},
+		VpcEndpointIds: vpcEndpointIds,
 	})
 	if err != nil {
 		return nil, err
@@ -35,6 +40,21 @@ func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 	}
 
 	return resources, nil
+}
+
+func getOpenSearchVpcEndpointIds(svc *opensearchservice.OpenSearchService) ([]*string, error) {
+	vpcEndpointIds := make([]*string, 0)
+
+	listResp, err := svc.ListVpcEndpoints(&opensearchservice.ListVpcEndpointsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vpcEndpoint := range listResp.VpcEndpointSummaryList {
+		vpcEndpointIds = append(vpcEndpointIds, vpcEndpoint.VpcEndpointId)
+	}
+
+	return vpcEndpointIds, nil
 }
 
 func (o *OSVPCEndpoint) Remove() error {


### PR DESCRIPTION
This PR includes two new modules for Opensearch [Packages](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/custom-packages.html) and [VPC Endpoints](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc-interface-endpoints.html). 

### Testing

Opensearch packages and VPC endpoints were created. using the setup code mentioned below, and then AWS Nuke was used to clean these resources up, specifying  `OSPackage` and `OSVPCEndpoint`.  

`us-east-1 - OSVPCEndpoint - aos-a50c4cac2357 - [VpcEndpointId: "aos-a50c4cac2357"] - would remove`
`us-east-1 - OSDomain - test-domain - [LastUpdatedTime: "2023-08-24T13:45:54Z"] - would remove`
`Scan complete: 2 total, 2 nukeable, 0 filtered.`

### Setup code

```
# Create an OpenSearch domain
echo "Creating OpenSearch domain"
DOMAIN=`aws opensearch create-domain --domain-name mylogs --engine-version OpenSearch_1.2 --cluster-config  InstanceType=t3.small.search,InstanceCount=1 --ebs-options EBSEnabled=true,VolumeType=gp3,VolumeSize=100,Iops=3500,Throughput=125 --access-policies '{"Version": "2012-10-17", "Statement": [{"Action": "es:*", "Principal":"*","Effect": "Allow", "Condition": {"IpAddress":{"aws:SourceIp":["192.0.2.0/32"]}}}]}'`

# Extract the domain name using grep and awk
DOMAIN_NAME=$(echo "$DOMAIN" | grep -o '"DomainName": "[^"]*' | awk -F'"' '{print $4}')

# Print the extracted domain name
echo "The domain name is: $DOMAIN_NAME"

# Extract the ARN using grep and awk
DOMAIN_ARN=$(echo "$DOMAIN" | grep -o '"ARN": "[^"]*' | awk -F'"' '{print $4}')
echo "The domain ARN is: $DOMAIN_ARN"

# Create a file to upload to S3
echo "Generating file to upload to S3 for OpenSearch custom package"
cat <<EOF > synonyms.txt
danish, croissant, pastry
ice cream, gelato, frozen custard
sneaker, tennis shoe, running shoe
basketball shoe, hightop
EOF

# Generate a random string to use as a bucket name
RANDOM_STRING=$(openssl rand -hex 20)

# Create a S3 Bucket to store the file:
echo "Creating S3 bucket to store OpenSearch custom package file"
aws s3api create-bucket --bucket opensearch-packages-$RANDOM_STRING --region us-east-1

# Copy the provided generated synonym to the S3 bucket:
echo "Uploading file to S3 bucket"
aws s3 cp ./synonyms.txt s3://opensearch-packages-$RANDOM_STRING

# Creating an OpenSearch custom package (Note: This command will fail if the bucket and file do not exist)
echo "Creating OpenSearch custom package"
aws opensearch create-package --package-name test-package --package-type 'TXT-DICTIONARY' --package-source '{"S3BucketName": "'"opensearch-packages-$RANDOM_STRING"'", "S3Key": "synonyms.txt"}'


echo "Getting a subnet from the default VPC"
DEFAULT_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query 'Vpcs[0].VpcId' --output text)

SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$DEFAULT_VPC_ID" "Name=availability-zone,Values=us-east-1*" --query 'Subnets[0].SubnetId' --output text)
echo "Using subnet $SUBNET_ID"

# Get the security group ID
SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$DEFAULT_VPC_ID" --query 'SecurityGroups[0].GroupId' --output text)
echo "Using security group $SECURITY_GROUP_ID"

# Create an Opensearch VPC Endpoint (Note: Using the default VPC appears to work intermittently, but creating a new VPC and then creating the VPC endpoint works consistently)
echo "Creating OpenSearch VPC Endpoint"
VPC_OPTIONS='{"SubnetIds": ["'"$SUBNET_ID"'"], "SecurityGroupIds": ["'"$SECURITY_GROUP_ID"'"]}'
echo "VPC options: $VPC_OPTIONS"

# Create the VPC endpoint
aws opensearch create-vpc-endpoint \
  --domain-arn "$DOMAIN_ARN" \
  --vpc-options "$VPC_OPTIONS"
```