### PR TITLE
feat: MemoryDB resource support

### DIFF
--- a/resources/memorydb-acl.go
+++ b/resources/memorydb-acl.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type MemoryDBACL struct {
+	svc  *memorydb.MemoryDB
+	name *string
+	tags []*memorydb.Tag
+}
+
+func init() {
+	register("MemoryDBACL", ListMemoryDBACLs)
+}
+
+func ListMemoryDBACLs(sess *session.Session) ([]Resource, error) {
+	svc := memorydb.New(sess)
+	var resources []Resource
+
+	params := &memorydb.DescribeACLsInput{MaxResults: aws.Int64(50)}
+	for {
+		resp, err := svc.DescribeACLs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, acl := range resp.ACLs {
+			tags, err := svc.ListTags(&memorydb.ListTagsInput{
+				ResourceArn: acl.ARN,
+			})
+
+			if err != nil {
+				continue
+			}
+
+			resources = append(resources, &MemoryDBACL{
+				svc:  svc,
+				name: acl.Name,
+				tags: tags.TagList,
+			})
+
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (i *MemoryDBACL) Remove() error {
+	params := &memorydb.DeleteACLInput{
+		ACLName: i.name,
+	}
+
+	_, err := i.svc.DeleteACL(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemoryDBACL) String() string {
+	return *i.name
+}
+
+func (i *MemoryDBACL) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", i.name)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
+}

--- a/resources/memorydb-cluster.go
+++ b/resources/memorydb-cluster.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type MemoryDBCluster struct {
+	svc  *memorydb.MemoryDB
+	name *string
+	tags []*memorydb.Tag
+}
+
+func init() {
+	register("MemoryDBCluster", ListMemoryDbClusters)
+}
+
+func ListMemoryDbClusters(sess *session.Session) ([]Resource, error) {
+	svc := memorydb.New(sess)
+	var resources []Resource
+
+	params := &memorydb.DescribeClustersInput{MaxResults: aws.Int64(100)}
+
+	for {
+		resp, err := svc.DescribeClusters(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cluster := range resp.Clusters {
+			tags, err := svc.ListTags(&memorydb.ListTagsInput{
+				ResourceArn: cluster.ARN,
+			})
+
+			if err != nil {
+				continue
+			}
+
+			resources = append(resources, &MemoryDBCluster{
+				svc:  svc,
+				name: cluster.Name,
+				tags: tags.TagList,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (c *MemoryDBCluster) Remove() error {
+	params := &memorydb.DeleteClusterInput{
+		ClusterName: c.name,
+	}
+
+	_, err := c.svc.DeleteCluster(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemoryDBCluster) String() string {
+	return *i.name
+}
+
+func (i *MemoryDBCluster) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", i.name)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
+}

--- a/resources/memorydb-parametergroups.go
+++ b/resources/memorydb-parametergroups.go
@@ -1,0 +1,98 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type MemoryDBParameterGroup struct {
+	svc    *memorydb.MemoryDB
+	name   *string
+	family *string
+	tags   []*memorydb.Tag
+}
+
+func init() {
+	register("MemoryDBParameterGroup", ListMemoryDBParameterGroups)
+}
+
+func ListMemoryDBParameterGroups(sess *session.Session) ([]Resource, error) {
+	svc := memorydb.New(sess)
+	var resources []Resource
+
+	params := &memorydb.DescribeParameterGroupsInput{MaxResults: aws.Int64(100)}
+
+	for {
+		resp, err := svc.DescribeParameterGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, parameterGroup := range resp.ParameterGroups {
+			tags, err := svc.ListTags(&memorydb.ListTagsInput{
+				ResourceArn: parameterGroup.ARN,
+			})
+
+			if err != nil {
+				continue
+			}
+
+			resources = append(resources, &MemoryDBParameterGroup{
+				svc:    svc,
+				name:   parameterGroup.Name,
+				family: parameterGroup.Family,
+				tags:   tags.TagList,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (i *MemoryDBParameterGroup) Filter() error {
+	if strings.HasPrefix(*i.name, "default.") {
+		return fmt.Errorf("Cannot delete default parameter group")
+	}
+	return nil
+}
+
+func (i *MemoryDBParameterGroup) Remove() error {
+	params := &memorydb.DeleteParameterGroupInput{
+		ParameterGroupName: i.name,
+	}
+
+	_, err := i.svc.DeleteParameterGroup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemoryDBParameterGroup) String() string {
+	return *i.name
+}
+
+func (i *MemoryDBParameterGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Name", i.name).
+		Set("Family", i.family)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
+}

--- a/resources/memorydb-subnetgroups.go
+++ b/resources/memorydb-subnetgroups.go
@@ -1,0 +1,85 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type MemoryDBSubnetGroup struct {
+	svc  *memorydb.MemoryDB
+	name *string
+	tags []*memorydb.Tag
+}
+
+func init() {
+	register("MemoryDBSubnetGroup", ListMemoryDBSubnetGroups)
+}
+
+func ListMemoryDBSubnetGroups(sess *session.Session) ([]Resource, error) {
+	svc := memorydb.New(sess)
+	var resources []Resource
+
+	params := &memorydb.DescribeSubnetGroupsInput{MaxResults: aws.Int64(100)}
+
+	for {
+		resp, err := svc.DescribeSubnetGroups(params)
+		if err != nil {
+			return nil, err
+		}
+		for _, subnetGroup := range resp.SubnetGroups {
+			tags, err := svc.ListTags(&memorydb.ListTagsInput{
+				ResourceArn: subnetGroup.ARN,
+			})
+
+			if err != nil {
+				continue
+			}
+
+			resources = append(resources, &MemoryDBSubnetGroup{
+				svc:  svc,
+				name: subnetGroup.Name,
+				tags: tags.TagList,
+			})
+
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (i *MemoryDBSubnetGroup) Remove() error {
+	params := &memorydb.DeleteSubnetGroupInput{
+		SubnetGroupName: i.name,
+	}
+
+	_, err := i.svc.DeleteSubnetGroup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemoryDBSubnetGroup) String() string {
+	return *i.name
+}
+
+func (i *MemoryDBSubnetGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Name", i.name)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
+}

--- a/resources/memorydb-user.go
+++ b/resources/memorydb-user.go
@@ -1,0 +1,95 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type MemoryDBUser struct {
+	svc  *memorydb.MemoryDB
+	name *string
+	tags []*memorydb.Tag
+}
+
+func init() {
+	register("MemoryDBUser", ListMemoryDBUsers)
+}
+
+func ListMemoryDBUsers(sess *session.Session) ([]Resource, error) {
+	svc := memorydb.New(sess)
+	var resources []Resource
+
+	params := &memorydb.DescribeUsersInput{MaxResults: aws.Int64(50)}
+	for {
+		resp, err := svc.DescribeUsers(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range resp.Users {
+			tags, err := svc.ListTags(&memorydb.ListTagsInput{
+				ResourceArn: user.ARN,
+			})
+
+			if err != nil {
+				continue
+			}
+
+			resources = append(resources, &MemoryDBUser{
+				svc:  svc,
+				name: user.Name,
+				tags: tags.TagList,
+			})
+
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (i *MemoryDBUser) Filter() error {
+	if strings.EqualFold(*i.name, "default") {
+		return fmt.Errorf("Cannot delete default user")
+	}
+	return nil
+}
+
+func (i *MemoryDBUser) Remove() error {
+	params := &memorydb.DeleteUserInput{
+		UserName: i.name,
+	}
+
+	_, err := i.svc.DeleteUser(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemoryDBUser) String() string {
+	return *i.name
+}
+
+func (i *MemoryDBUser) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Name", i.name)
+
+	for _, tag := range i.tags {
+		properties.SetTag(tag.Key, tag.Value)
+	}
+
+	return properties
+}


### PR DESCRIPTION
feat: MemoryDBACL resource support
feat: MemoryDBCluster resource support
feat: MemoryDBParameterGroup resource support
feat: MemoryDBSubnetGroup resource support
feat: MemoryDBUser resource support

These resources are mostly the same as the Elasticache equivalents with pagination and properties added. Tested that all resources get deleted against our own AWS account.