### PR TITLE
Fix: Don't delete predefined deployment strategies

### DIFF
--- a/resources/appconfig-deploymentstrategies.go
+++ b/resources/appconfig-deploymentstrategies.go
@@ -1,6 +1,9 @@
 package resources
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/appconfig"
@@ -37,6 +40,13 @@ func ListAppConfigDeploymentStrategies(sess *session.Session) ([]Resource, error
 		return nil, err
 	}
 	return resources, nil
+}
+
+func (f *AppConfigDeploymentStrategy) Filter() error {
+	if strings.HasPrefix(*f.name, "AppConfig.") {
+		return fmt.Errorf("cannot delete predefined Deployment Strategy")
+	}
+	return nil
 }
 
 func (f *AppConfigDeploymentStrategy) Remove() error {


### PR DESCRIPTION
Unfortunately there was another error in the AppConfig code, as it caused some of these:
```
BadRequestException: Cannot delete predefined Deployment Strategy AppConfig.Linear50PercentEvery30Seconds
Message_:  "Cannot delete predefined Deployment Strategy AppConfig.Linear50PercentEvery30Seconds."
```

This change should fix it.

/cc @tbarrella