### PR TITLE
Stop building ARM containers for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
       id: generate_tags
 
     - name: Set up QEMU
+      if: github.event_name != 'pull_request'
       id: qemu
       uses: docker/setup-qemu-action@v2
       with:
@@ -88,4 +89,4 @@ jobs:
         context: .
         push: true
         tags: ${{ steps.generate_tags.outputs.tags }}
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}


### PR DESCRIPTION
This simply takes way too long and is probably unused most of the time anyway. Releases are still built for ARM.