### PR TITLE
Defuse unnecessary errors for unavailable services

### DIFF
--- a/resources/fms_notification_channels.go
+++ b/resources/fms_notification_channels.go
@@ -1,10 +1,13 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/fms"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 type FMSNotificationChannel struct {
@@ -21,8 +24,9 @@ func ListFMSNotificationChannel(sess *session.Session) ([]Resource, error) {
 
 	if _, err := svc.GetNotificationChannel(&fms.GetNotificationChannelInput{}); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() != fms.ErrCodeResourceNotFoundException {
-				return nil, err
+			if strings.Contains(aerr.Message(), "No default admin could be found") {
+				logrus.Infof("FMSNotificationChannel: %s. Ignore if you haven't set it up.", aerr.Message())
+				return nil, nil
 			}
 		} else {
 			return nil, err

--- a/resources/fms_policies.go
+++ b/resources/fms_policies.go
@@ -1,10 +1,14 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/fms"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 type FMSPolicy struct {
@@ -27,6 +31,12 @@ func ListFMSPolicies(sess *session.Session) ([]Resource, error) {
 	for {
 		resp, err := svc.ListPolicies(params)
 		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "No default admin could be found") {
+					logrus.Infof("FMSPolicy: %s. Ignore if you haven't set it up.", aerr.Message())
+					return nil, nil
+				}
+			}
 			return nil, err
 		}
 

--- a/resources/machinelearning-batchpredictions.go
+++ b/resources/machinelearning-batchpredictions.go
@@ -1,9 +1,13 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/sirupsen/logrus"
 )
 
 type MachineLearningBranchPrediction struct {
@@ -26,6 +30,12 @@ func ListMachineLearningBranchPredictions(sess *session.Session) ([]Resource, er
 	for {
 		output, err := svc.DescribeBatchPredictions(params)
 		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "AmazonML is no longer available to new customers") {
+					logrus.Info("MachineLearningBranchPrediction: AmazonML is no longer available to new customers. Ignore if you haven't set it up.")
+					return nil, nil
+				}
+			}
 			return nil, err
 		}
 

--- a/resources/machinelearning-datasources.go
+++ b/resources/machinelearning-datasources.go
@@ -1,9 +1,13 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/sirupsen/logrus"
 )
 
 type MachineLearningDataSource struct {
@@ -26,6 +30,12 @@ func ListMachineLearningDataSources(sess *session.Session) ([]Resource, error) {
 	for {
 		output, err := svc.DescribeDataSources(params)
 		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "AmazonML is no longer available to new customers") {
+					logrus.Info("MachineLearningBranchPrediction: AmazonML is no longer available to new customers. Ignore if you haven't set it up.")
+					return nil, nil
+				}
+			}
 			return nil, err
 		}
 

--- a/resources/machinelearning-evaluations.go
+++ b/resources/machinelearning-evaluations.go
@@ -1,9 +1,13 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/sirupsen/logrus"
 )
 
 type MachineLearningEvaluation struct {
@@ -26,6 +30,12 @@ func ListMachineLearningEvaluations(sess *session.Session) ([]Resource, error) {
 	for {
 		output, err := svc.DescribeEvaluations(params)
 		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "AmazonML is no longer available to new customers") {
+					logrus.Info("MachineLearningBranchPrediction: AmazonML is no longer available to new customers. Ignore if you haven't set it up.")
+					return nil, nil
+				}
+			}
 			return nil, err
 		}
 

--- a/resources/machinelearning-mlmodels.go
+++ b/resources/machinelearning-mlmodels.go
@@ -1,9 +1,13 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/sirupsen/logrus"
 )
 
 type MachineLearningMLModel struct {
@@ -26,6 +30,12 @@ func ListMachineLearningMLModels(sess *session.Session) ([]Resource, error) {
 	for {
 		output, err := svc.DescribeMLModels(params)
 		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "AmazonML is no longer available to new customers") {
+					logrus.Info("MachineLearningBranchPrediction: AmazonML is no longer available to new customers. Ignore if you haven't set it up.")
+					return nil, nil
+				}
+			}
 			return nil, err
 		}
 

--- a/resources/mgn-jobs.go
+++ b/resources/mgn-jobs.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/mgn"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 type MGNJob struct {
@@ -29,6 +30,10 @@ func ListMGNJobs(sess *session.Session) ([]Resource, error) {
 	for {
 		output, err := svc.DescribeJobs(params)
 		if err != nil {
+			if IsAWSError(err, mgn.ErrCodeUninitializedAccountException) {
+				logrus.Info("MGNJob: Account not initialized for Application Migration Service. Ignore if you haven't set it up.")
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/resources/mgn-source_servers.go
+++ b/resources/mgn-source_servers.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/mgn"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 type MGNSourceServer struct {
@@ -29,6 +30,10 @@ func ListMGNSourceServers(sess *session.Session) ([]Resource, error) {
 	for {
 		output, err := svc.DescribeSourceServers(params)
 		if err != nil {
+			if IsAWSError(err, mgn.ErrCodeUninitializedAccountException) {
+				logrus.Info("MGNSourceServer: Account not initialized for Application Migration Service. Ignore if you haven't set it up.")
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Fixes #341

These errors pop up when you are not actually using the service. Since they are just confusing the users and are no actual errors, make them `Info` level and pretty-print it.

Before:
```
ERRO[0026] Listing MachineLearningDataSource failed:
    AccessDeniedException: Thank you for your interest in Amazon Machine Learning. AmazonML is no longer available to new customers.  Please consider using Amazon SageMaker.
    	status code: 403, request id: abcdefg-1234
ERRO[0024] Listing MGNSourceServer failed:
    UninitializedAccountException: Account not initialized
    {
      RespMetadata: {
        StatusCode: 400,
        RequestID: "abcdefg-1234"
      },
      Message_: "Account not initialized"
    } 
ERRO[0024] Listing FMSPolicy failed:
    AccessDeniedException: No default admin could be found for account 123456789012 in Region us-east-1
    	status code: 400, request id: abcdefg-1234
```

After:
```
INFO[0021] MGNSourceServer: Account not initialized for Application Migration Service. Ignore if you haven't set it up. 
INFO[0021] MGNJob: Account not initialized for Application Migration Service. Ignore if you haven't set it up.
INFO[0021] FMSPolicy: No default admin could be found for account 238905726876 in Region us-east-1. Ignore if you haven't set it up. 
INFO[0024] FMSNotificationChannel: No default admin could be found for account 238905726876 in Region us-east-1. Ignore if you haven't set it up. 
INFO[0024] MachineLearningBranchPrediction: AmazonML is no longer available to new customers. Ignore if you haven't set it up.
```