### PR TITLE
add snapshot schedule

### DIFF
--- a/resources/redshift-snapshot-schedule.go
+++ b/resources/redshift-snapshot-schedule.go
@@ -1,0 +1,81 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type RedshiftSnapshotSchedule struct {
+	svc                *redshift.Redshift
+	scheduleID         *string
+	associatedClusters []*redshift.ClusterAssociatedToSchedule
+}
+
+func init() {
+	register("RedshiftSnapshotSchedule", ListRedshiftSnapshotSchedule)
+}
+
+func ListRedshiftSnapshotSchedule(sess *session.Session) ([]Resource, error) {
+	svc := redshift.New(sess)
+	resources := []Resource{}
+
+	params := &redshift.DescribeSnapshotSchedulesInput{
+		MaxRecords: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.DescribeSnapshotSchedules(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, snapshotSchedule := range output.SnapshotSchedules {
+			resources = append(resources, &RedshiftSnapshotSchedule{
+				svc:                svc,
+				scheduleID:         snapshotSchedule.ScheduleIdentifier,
+				associatedClusters: snapshotSchedule.AssociatedClusters,
+			})
+		}
+
+		if output.Marker == nil {
+			break
+		}
+
+		params.Marker = output.Marker
+	}
+
+	return resources, nil
+}
+
+func (f *RedshiftSnapshotSchedule) Properties() types.Properties {
+	associatedClusters := make([]string, len(f.associatedClusters))
+	for i, cluster := range f.associatedClusters {
+		associatedClusters[i] = *cluster.ClusterIdentifier
+	}
+	properties := types.NewProperties()
+	properties.Set("scheduleID", f.scheduleID)
+	properties.Set("associatedClusters", associatedClusters)
+	return properties
+}
+
+func (f *RedshiftSnapshotSchedule) Remove() error {
+	for _, associatedCluster := range f.associatedClusters {
+		_, disassociateErr := f.svc.ModifyClusterSnapshotSchedule(&redshift.ModifyClusterSnapshotScheduleInput{
+			ScheduleIdentifier:   f.scheduleID,
+			ClusterIdentifier:    associatedCluster.ClusterIdentifier,
+			DisassociateSchedule: aws.Bool(true),
+		})
+
+		if disassociateErr != nil {
+			return disassociateErr
+		}
+	}
+
+	_, err := f.svc.DeleteSnapshotSchedule(&redshift.DeleteSnapshotScheduleInput{
+		ScheduleIdentifier: f.scheduleID,
+	})
+
+	return err
+}


### PR DESCRIPTION
This closes #1097 

Adds snapshots schedules for redshift. When the schedule has no cluster associated: 
```
eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[]", scheduleID: "automated-snapshots-24-hours"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID xxx and the alias 'xxx'?
Waiting 15s before continuing.
eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[]", scheduleID: "automated-snapshots-24-hours"] - triggered remove

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[]", scheduleID: "automated-snapshots-24-hours"] - waiting

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[]", scheduleID: "automated-snapshots-24-hours"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished

```

When it does: 
```
eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[main]", scheduleID: "automated-snapshots-24-hours"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID xxx and the alias 'xxx'?
Waiting 15s before continuing.
in error: error: SnapshotScheduleNotFoundeu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[main]", scheduleID: "automated-snapshots-24-hours"] - failed

Removal requested: 0 waiting, 1 failed, 0 skipped, 0 finished

eu-central-1 - RedshiftSnapshotSchedule - [associatedClusters: "[main]", scheduleID: "automated-snapshots-24-hours"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished

Nuke complete: 0 failed, 0 skipped, 1 finished.
```

It will report status `failed` initially since it has to disassociate from the clusters, and this takes a little bit of time. After retrying, it will report `removed` status. I did not want to include a sleep in the `Remove()` function because this would include necessary waiting time during program execution. 