### PR TITLE
add tags filtering for VPCEndpointService

### DIFF
--- a/resources/ec2-vpc-endpoint-service-configurations.go
+++ b/resources/ec2-vpc-endpoint-service-configurations.go
@@ -11,6 +11,7 @@ type EC2VPCEndpointServiceConfiguration struct {
 	svc  *ec2.EC2
 	id   *string
 	name *string
+	tags []*ec2.Tag
 }
 
 func init() {
@@ -36,6 +37,7 @@ func ListEC2VPCEndpointServiceConfigurations(sess *session.Session) ([]Resource,
 				svc:  svc,
 				id:   serviceConfig.ServiceId,
 				name: serviceConfig.ServiceName,
+				tags: serviceConfig.Tags,
 			})
 		}
 
@@ -64,6 +66,9 @@ func (e *EC2VPCEndpointServiceConfiguration) Remove() error {
 func (e *EC2VPCEndpointServiceConfiguration) Properties() types.Properties {
 	properties := types.NewProperties()
 	properties.Set("Name", e.name)
+	for _, tagValue := range e.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
 	return properties
 }
 


### PR DESCRIPTION
I wanted to nuke some VPCEndpointService resources by filtering with tags but aws-nuke did not return any of the existing resources. 

Here is the config file :
```
regions:
  - "eu-central-1"

account-blocklist:
- YYYYYY

# optional: restrict nuking to these resources
resource-types:
  targets:
  - EC2VPCEndpointServiceConfiguration

accounts:
  "XXXXXXXXX":
    presets:
    - common

presets:
  common:
    filters:
      EC2VPCEndpointServiceConfiguration:
      - property: "tag:Classification"
        value: "TEST"
        invert: true
```

I found this issue https://github.com/rebuy-de/aws-nuke/issues/958 and saw that indeed, the EC2VPCEndpointServiceConfiguration was not using the tags in the `Properties()` func.
This PR aims to fix it for this resource.

I tested aws-nuke before and after the fix and here are the results :

```
# current version => do no return my VPCEndpointService
aws-nuke -c nuke.yaml -q
Scan complete: 12 total, 0 nukeable, 12 filtered.

# PR version => returns the VPCEndpointService as "nukeable"
./dist/aws-nuke -c nuke.yaml -q
Scan complete: 12 total, 1 nukeable, 11 filtered.
```