### PR TITLE
feat: Add filter for default OpenSearch Service packages

### DIFF
--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -1,6 +1,8 @@
 package resources
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -52,6 +54,13 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 	}
 
 	return resources, nil
+}
+
+func (i *OSPackage) Filter() error {
+	if strings.HasPrefix(*i.packageName, "analysis-") || strings.HasPrefix(*i.packageName, "amazon-") {
+		return fmt.Errorf("Cannot delete default OpenSearch Service packages")
+	}
+	return nil
 }
 
 func (o *OSPackage) Remove() error {


### PR DESCRIPTION
# Summary

Adding filter for OpenSearch Service default packages

## Fixes

#1123 

## Testing

```
us-east-2 - OSPackage - G100932326 - [CreatedTime: "2023-10-12T21:13:33Z", PackageID: "G100932326", PackageName: "analysis-nori"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G109829856 - [CreatedTime: "2023-10-12T21:42:39Z", PackageID: "G109829856", PackageName: "analysis-stconvert"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G133674843 - [CreatedTime: "2023-10-12T21:35:10Z", PackageID: "G133674843", PackageName: "analysis-stconvert"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G145112168 - [CreatedTime: "2023-10-12T21:15:37Z", PackageID: "G145112168", PackageName: "analysis-nori"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G154009698 - [CreatedTime: "2023-10-12T21:46:37Z", PackageID: "G154009698", PackageName: "analysis-stconvert"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G16813460 - [CreatedTime: "2023-10-12T23:01:16Z", PackageID: "G16813460", PackageName: "analysis-pinyin"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G168957155 - [CreatedTime: "2023-10-12T23:32:36Z", PackageID: "G168957155", PackageName: "analysis-nori"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G173044245 - [CreatedTime: "2023-10-12T21:24:01Z", PackageID: "G173044245", PackageName: "analysis-pinyin"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G189292010 - [CreatedTime: "2023-10-12T23:04:19Z", PackageID: "G189292010", PackageName: "analysis-nori"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G21470172 - [CreatedTime: "2023-10-12T21:35:41Z", PackageID: "G21470172", PackageName: "analysis-stconvert"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G215239247 - [CreatedTime: "2023-10-12T21:48:23Z", PackageID: "G215239247", PackageName: "analysis-sudachi"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G217224087 - [CreatedTime: "2023-10-12T23:35:37Z", PackageID: "G217224087", PackageName: "analysis-pinyin"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G259419089 - [CreatedTime: "2023-10-12T21:54:22Z", PackageID: "G259419089", PackageName: "analysis-sudachi"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G261403929 - [CreatedTime: "2023-10-12T23:05:26Z", PackageID: "G261403929", PackageName: "analysis-pinyin"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G35163475 - [CreatedTime: "2023-10-12T21:55:59Z", PackageID: "G35163475", PackageName: "analysis-sudachi"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G37148315 - [CreatedTime: "2023-10-12T21:31:35Z", PackageID: "G37148315", PackageName: "analysis-pinyin"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G56752484 - [CreatedTime: "2023-10-12T21:11:41Z", PackageID: "G56752484", PackageName: "analysis-nori"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G59008462 - [CreatedTime: "2023-10-12T21:48:08Z", PackageID: "G59008462", PackageName: "analysis-sudachi"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G65650014 - [CreatedTime: "2023-10-12T21:39:31Z", PackageID: "G65650014", PackageName: "analysis-stconvert"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G69372995 - [CreatedTime: "2023-10-16T20:57:30Z", PackageID: "G69372995", PackageName: "amazon-personalized-ranking"] - Cannot delete default OpenSearch packages
us-east-2 - OSPackage - G79343317 - [CreatedTime: "2023-10-12T21:57:46Z", PackageID: "G79343317", PackageName: "analysis-sudachi"] - Cannot delete default OpenSearch packages
```