### PR TITLE
Fixing a null pointer exception in Route53ResolverRule

### DIFF
--- a/resources/route53-resolver-rules.go
+++ b/resources/route53-resolver-rules.go
@@ -100,7 +100,7 @@ func resolverRulesToVpcIDs(svc *route53resolver.Route53Resolver) (map[string][]*
 
 // Filter removes resources automatically from being nuked
 func (r *Route53ResolverRule) Filter() error {
-	if *r.domainName == "." {
+	if r.domainName != nil && *r.domainName == "." {
 		return fmt.Errorf(`Filtering DomainName "."`)
 	}
 


### PR DESCRIPTION
When we are running nuke, we get the following error:


```
goroutine 1 [running]:
--
690 | github.com/rebuy-de/aws-nuke/v2/resources.(*Route53ResolverRule).Filter(0xc002339430?)
691 | /src/resources/route53-resolver-rules.go:103 +0x12
692 | github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Filter(0xc0003c8840, 0xc0013afcc0)
693 | /src/cmd/nuke.go:196 +0x53
694 | github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Scan(0xc0003c8840)
695 | /src/cmd/nuke.go:173 +0x9cb
696 | github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Run(0xc0003c8840)
697 | /src/cmd/nuke.go:61 +0x325
698 | github.com/rebuy-de/aws-nuke/v2/cmd.NewRootCommand.func2(0xc00034e800?, {0x5843b0d?, 0x4?, 0x5843b11?})
699 | /src/cmd/root.go:92 +0x613
700 | github.com/spf13/cobra.(*Command).execute(0xc0002c8300, {0xc0000b4010, 0xb, 0xb})
701 | /src/vendor/github.com/spf13/cobra/command.go:940 +0x87c
702 | github.com/spf13/cobra.(*Command).ExecuteC(0xc0002c8300)
703 | /src/vendor/github.com/spf13/cobra/command.go:1068 +0x3a5
704 | github.com/spf13/cobra.(*Command).Execute(0xc0000061a0?)
705 | /src/vendor/github.com/spf13/cobra/command.go:992 +0x13
706 | main.main()
707 | /src/main.go:10 +0x18
708 |  
709 | [Container] 2023/10/25 23:04:14.209271 Command did not exit successfully bin/destroy --no-dry-run --force exit status 2
710 | [Container] 2023/10/25 23:04:14.212499 Phase complete: BUILD State: FAILED
```

This doesn't happen for all regions. It happens for us-east-1.
