### PR TITLE
Delete DMS Certificate not Endpoint in DatabaseMigrationServiceCertificate Remove function

### DIFF
--- a/resources/databasemigrationservice-certificates.go
+++ b/resources/databasemigrationservice-certificates.go
@@ -48,8 +48,8 @@ func ListDatabaseMigrationServiceCertificates(sess *session.Session) ([]Resource
 
 func (f *DatabaseMigrationServiceCertificate) Remove() error {
 
-	_, err := f.svc.DeleteEndpoint(&databasemigrationservice.DeleteEndpointInput{
-		EndpointArn: f.ARN,
+	_, err := f.svc.DeleteCertificate(&databasemigrationservice.DeleteCertificateInput{
+		CertificateArn: f.ARN,
 	})
 
 	return err


### PR DESCRIPTION
It appears that DatabaseMigrationServiceCertificate was created with copy/paste and some values weren't changed.  I think this change will allow aws-nuke to delete DMS certificates when removing resources.  Currently aws-nuke leaves DMS certificates around when destroying AWS accounts.