### PR TITLE
Delete core network resources

### DIFF
--- a/resources/networkmanager-connect-peers.go
+++ b/resources/networkmanager-connect-peers.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type NetworkManagerConnectPeer struct {
+	svc  *networkmanager.NetworkManager
+	peer *networkmanager.ConnectPeerSummary
+}
+
+func init() {
+	register("NetworkManagerConnectPeer", ListNetworkManagerConnectPeers)
+}
+
+func ListNetworkManagerConnectPeers(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	params := &networkmanager.ListConnectPeersInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListConnectPeers(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, connectPeer := range resp.ConnectPeers {
+		resources = append(resources, &NetworkManagerConnectPeer{
+			svc:  svc,
+			peer: connectPeer,
+		})
+	}
+
+	return resources, nil
+}
+
+func (n *NetworkManagerConnectPeer) Remove() error {
+	params := &networkmanager.DeleteConnectPeerInput{
+		ConnectPeerId: n.peer.ConnectPeerId,
+	}
+
+	_, err := n.svc.DeleteConnectPeer(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (n *NetworkManagerConnectPeer) Filter() error {
+	if strings.ToLower(*n.peer.ConnectPeerState) == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (n *NetworkManagerConnectPeer) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range n.peer.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("ID", n.peer.ConnectPeerId)
+	return properties
+}
+
+func (n *NetworkManagerConnectPeer) String() string {
+	return *n.peer.ConnectPeerId
+}

--- a/resources/networkmanager-core-network.go
+++ b/resources/networkmanager-core-network.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type NetworkManagerCoreNetwork struct {
+	svc     *networkmanager.NetworkManager
+	network *networkmanager.CoreNetworkSummary
+}
+
+func init() {
+	register("NetworkManagerCoreNetwork", ListNetworkManagerCoreNetworks)
+}
+
+func ListNetworkManagerCoreNetworks(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	params := &networkmanager.ListCoreNetworksInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListCoreNetworks(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, network := range resp.CoreNetworks {
+		resources = append(resources, &NetworkManagerCoreNetwork{
+			svc:     svc,
+			network: network,
+		})
+	}
+
+	return resources, nil
+}
+
+func (n *NetworkManagerCoreNetwork) Remove() error {
+	params := &networkmanager.DeleteCoreNetworkInput{
+		CoreNetworkId: n.network.CoreNetworkId,
+	}
+
+	_, err := n.svc.DeleteCoreNetwork(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (n *NetworkManagerCoreNetwork) Filter() error {
+	if strings.ToLower(*n.network.State) == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (n *NetworkManagerCoreNetwork) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range n.network.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.
+		Set("ID", n.network.CoreNetworkId).
+		Set("ARN", n.network.CoreNetworkArn)
+	return properties
+}
+
+func (n *NetworkManagerCoreNetwork) String() string {
+	return *n.network.CoreNetworkId
+}

--- a/resources/networkmanager-global-network.go
+++ b/resources/networkmanager-global-network.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type NetworkManagerGlobalNetwork struct {
+	svc     *networkmanager.NetworkManager
+	network *networkmanager.GlobalNetwork
+}
+
+func init() {
+	register("NetworkManagerGlobalNetwork", ListNetworkManagerGlobalNetworks)
+}
+
+func ListNetworkManagerGlobalNetworks(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	resources := []Resource{}
+
+	params := &networkmanager.DescribeGlobalNetworksInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		resp, err := svc.DescribeGlobalNetworks(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, network := range resp.GlobalNetworks {
+			resources = append(resources, &NetworkManagerGlobalNetwork{
+				svc:     svc,
+				network: network,
+			})
+		}
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+	return resources, nil
+}
+
+func (n *NetworkManagerGlobalNetwork) Remove() error {
+	params := &networkmanager.DeleteGlobalNetworkInput{
+		GlobalNetworkId: n.network.GlobalNetworkId,
+	}
+
+	_, err := n.svc.DeleteGlobalNetwork(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (n *NetworkManagerGlobalNetwork) Filter() error {
+	if strings.ToLower(*n.network.State) == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (n *NetworkManagerGlobalNetwork) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range n.network.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.
+		Set("ID", n.network.GlobalNetworkId).
+		Set("ARN", n.network.GlobalNetworkArn)
+	return properties
+}
+
+func (n *NetworkManagerGlobalNetwork) String() string {
+	return *n.network.GlobalNetworkId
+}

--- a/resources/networkmanager-network-attachments.go
+++ b/resources/networkmanager-network-attachments.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type NetworkManagerNetworkAttachment struct {
+	svc        *networkmanager.NetworkManager
+	attachment *networkmanager.Attachment
+}
+
+func init() {
+	register("NetworkManagerNetworkAttachment", ListNetworkManagerNetworkAttachments)
+}
+
+func ListNetworkManagerNetworkAttachments(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	params := &networkmanager.ListAttachmentsInput{}
+	resources := make([]Resource, 0)
+
+	resp, err := svc.ListAttachments(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, attachment := range resp.Attachments {
+		resources = append(resources, &NetworkManagerNetworkAttachment{
+			svc:        svc,
+			attachment: attachment,
+		})
+	}
+
+	return resources, nil
+}
+
+func (n *NetworkManagerNetworkAttachment) Remove() error {
+	params := &networkmanager.DeleteAttachmentInput{
+		AttachmentId: n.attachment.AttachmentId,
+	}
+
+	_, err := n.svc.DeleteAttachment(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (n *NetworkManagerNetworkAttachment) Filter() error {
+	if strings.ToLower(*n.attachment.State) == "deleted" {
+		return fmt.Errorf("already deleted")
+	}
+
+	return nil
+}
+
+func (n *NetworkManagerNetworkAttachment) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range n.attachment.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.
+		Set("ID", n.attachment.AttachmentId).
+		Set("ARN", n.attachment.ResourceArn)
+	return properties
+}
+
+func (n *NetworkManagerNetworkAttachment) String() string {
+	return *n.attachment.AttachmentId
+}


### PR DESCRIPTION
*What?*
- Delete networkmanager connect peers.
- Delete networkmanager core networks.
- Delete networkmanager global networks.
- Delete networkmanager network attachments.

*Why?*
- Connect peers must be deleted first before deleting other core network resources.
- Deletion of the core networks, global networks and the network attachments are resources that weren't previously handled by aws-nuke.