### PR TITLE
Filter `IAMRolePolicy` resources related to SSO

### DIFF
--- a/resources/iam-role-policy.go
+++ b/resources/iam-role-policy.go
@@ -85,6 +85,9 @@ func (e *IAMRolePolicy) Filter() error {
 	if strings.HasPrefix(aws.StringValue(e.role.Path), "/aws-service-role/") {
 		return fmt.Errorf("cannot alter service roles")
 	}
+	if strings.HasPrefix(aws.StringValue(e.role.Path), "/aws-reserved/sso.amazonaws.com/") {
+		return fmt.Errorf("cannot alter SSO roles")
+	}
 	return nil
 }
 


### PR DESCRIPTION
This was implemented in #1028 for roles and policy attachments, but not for policies themselves, so they are still marked as to be removed:

```
global - IAMRolePolicy - AWSReservedSSO_OrgTechLeadAccess_4d1c5d3f2cc9cc4f -> AwsSSOInlinePolicy - [PolicyName: "AwsSSOInlinePolicy", role:CreateDate: "2023-09-14T17:33:55Z", role:LastUsed: "2023-09-14T17:33:55Z", role:Path: "/aws-reserved/sso.amazonaws.com/", role:RoleID: "AROAV622SCKYKH3U7G7YN", role:RoleName: "AWSReservedSSO_OrgTechLeadAccess_4d1c5d3f2cc9cc4f"] - would remove
```
