### PR TITLE
Fixed error handling for aws default opensearch packages

### DIFF
--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -67,8 +67,11 @@ func (o *OSPackage) Remove() error {
 	_, err := o.svc.DeletePackage(&opensearchservice.DeletePackageInput{
 		PackageID: o.packageID,
 	})
+    if err != nil {
+        return err
+	}
 
-	return err
+	return nil
 }
 
 func (o *OSPackage) Properties() types.Properties {


### PR DESCRIPTION
Hey, 
i have fixed the error handling for aws OSPackages.
Fixes #1123 

