### PR TITLE
Add support for Redshift Serverless namespaces, snapshots and workgroups.

### DIFF
--- a/resources/redshiftserverless-namespaces.go
+++ b/resources/redshiftserverless-namespaces.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type RedshiftServerlessNamespace struct {
+	svc       *redshiftserverless.RedshiftServerless
+	namespace *redshiftserverless.Namespace
+}
+
+func init() {
+	register("RedshiftServerlessNamespace", ListRedshiftServerlessNamespaces)
+}
+
+func ListRedshiftServerlessNamespaces(sess *session.Session) ([]Resource, error) {
+	svc := redshiftserverless.New(sess)
+	resources := []Resource{}
+
+	params := &redshiftserverless.ListNamespacesInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListNamespaces(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, namespace := range output.Namespaces {
+			resources = append(resources, &RedshiftServerlessNamespace{
+				svc:       svc,
+				namespace: namespace,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (n *RedshiftServerlessNamespace) Properties() types.Properties {
+	properties := types.NewProperties().
+		Set("CreationDate", n.namespace.CreationDate).
+		Set("NamespaceName", n.namespace.NamespaceName)
+
+	return properties
+}
+
+func (n *RedshiftServerlessNamespace) Remove() error {
+	_, err := n.svc.DeleteNamespace(&redshiftserverless.DeleteNamespaceInput{
+		NamespaceName: n.namespace.NamespaceName,
+	})
+
+	return err
+}
+
+func (n *RedshiftServerlessNamespace) String() string {
+	return *n.namespace.NamespaceName
+}

--- a/resources/redshiftserverless-snapshots.go
+++ b/resources/redshiftserverless-snapshots.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type RedshiftServerlessSnapshot struct {
+	svc      *redshiftserverless.RedshiftServerless
+	snapshot *redshiftserverless.Snapshot
+}
+
+func init() {
+	register("RedshiftServerlessSnapshot", ListRedshiftServerlessSnapshots)
+}
+
+func ListRedshiftServerlessSnapshots(sess *session.Session) ([]Resource, error) {
+	svc := redshiftserverless.New(sess)
+	resources := []Resource{}
+
+	params := &redshiftserverless.ListSnapshotsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListSnapshots(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, snapshot := range output.Snapshots {
+			resources = append(resources, &RedshiftServerlessSnapshot{
+				svc:      svc,
+				snapshot: snapshot,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (s *RedshiftServerlessSnapshot) Properties() types.Properties {
+	properties := types.NewProperties().
+		Set("CreateTime", s.snapshot.SnapshotCreateTime).
+		Set("Namespace", s.snapshot.NamespaceName).
+		Set("SnapshotName", s.snapshot.SnapshotName)
+
+	return properties
+}
+
+func (s *RedshiftServerlessSnapshot) Remove() error {
+	_, err := s.svc.DeleteSnapshot(&redshiftserverless.DeleteSnapshotInput{
+		SnapshotName: s.snapshot.SnapshotName,
+	})
+
+	return err
+}
+
+func (s *RedshiftServerlessSnapshot) String() string {
+	return *s.snapshot.SnapshotName
+}

--- a/resources/redshiftserverless-workgroups.go
+++ b/resources/redshiftserverless-workgroups.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type RedshiftServerlessWorkgroup struct {
+	svc       *redshiftserverless.RedshiftServerless
+	workgroup *redshiftserverless.Workgroup
+}
+
+func init() {
+	register("RedshiftServerlessWorkgroup", ListRedshiftServerlessWorkgroups)
+}
+
+func ListRedshiftServerlessWorkgroups(sess *session.Session) ([]Resource, error) {
+	svc := redshiftserverless.New(sess)
+	resources := []Resource{}
+
+	params := &redshiftserverless.ListWorkgroupsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListWorkgroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, workgroup := range output.Workgroups {
+			resources = append(resources, &RedshiftServerlessWorkgroup{
+				svc:       svc,
+				workgroup: workgroup,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (w *RedshiftServerlessWorkgroup) Properties() types.Properties {
+	properties := types.NewProperties().
+		Set("CreationDate", w.workgroup.CreationDate).
+		Set("Namespace", w.workgroup.NamespaceName).
+		Set("WorkgroupName", w.workgroup.WorkgroupName)
+
+	return properties
+}
+
+func (w *RedshiftServerlessWorkgroup) Remove() error {
+	_, err := w.svc.DeleteWorkgroup(&redshiftserverless.DeleteWorkgroupInput{
+		WorkgroupName: w.workgroup.WorkgroupName,
+	})
+
+	return err
+}
+
+func (w *RedshiftServerlessWorkgroup) String() string {
+	return *w.workgroup.WorkgroupName
+}


### PR DESCRIPTION
This PR adds support for Redshift Serverless [namespace, workgroup](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-workgroup-namespace.html) and [snapshot](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-snapshots-recovery-points.html) resources.