### PR TITLE
Add support for Sagemaker Spaces

### DIFF
--- a/resources/sagemaker-apps.go
+++ b/resources/sagemaker-apps.go
@@ -15,6 +15,7 @@ type SageMakerApp struct {
 	appName         *string
 	appType         *string
 	userProfileName *string
+	spaceName       *string
 	status          *string
 }
 
@@ -43,6 +44,7 @@ func ListSageMakerApps(sess *session.Session) ([]Resource, error) {
 				appName:         app.AppName,
 				appType:         app.AppType,
 				userProfileName: app.UserProfileName,
+				spaceName:       app.SpaceName,
 				status:          app.Status,
 			})
 		}
@@ -63,6 +65,7 @@ func (f *SageMakerApp) Remove() error {
 		AppName:         f.appName,
 		AppType:         f.appType,
 		UserProfileName: f.userProfileName,
+		SpaceName:       f.spaceName,
 	})
 
 	return err
@@ -78,7 +81,8 @@ func (i *SageMakerApp) Properties() types.Properties {
 		Set("DomainID", i.domainID).
 		Set("AppName", i.appName).
 		Set("AppType", i.appType).
-		Set("UserProfileName", i.userProfileName)
+		Set("UserProfileName", i.userProfileName).
+		Set("SpaceName", i.spaceName)
 	return properties
 }
 

--- a/resources/sagemaker-spaces.go
+++ b/resources/sagemaker-spaces.go
@@ -1,0 +1,82 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type SageMakerSpace struct {
+	svc              *sagemaker.SageMaker
+	domainID         *string
+	spaceDisplayName *string
+	spaceName        *string
+	status           *string
+	lastModifiedTime *time.Time
+}
+
+func init() {
+	register("SageMakerSpace", ListSageMakerSpaces)
+}
+
+func ListSageMakerSpaces(sess *session.Session) ([]Resource, error) {
+	svc := sagemaker.New(sess)
+	resources := []Resource{}
+
+	params := &sagemaker.ListSpacesInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListSpaces(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, space := range resp.Spaces {
+			resources = append(resources, &SageMakerSpace{
+				svc:              svc,
+				domainID:         space.DomainId,
+				spaceDisplayName: space.SpaceDisplayName,
+				spaceName:        space.SpaceName,
+				status:           space.Status,
+				lastModifiedTime: space.LastModifiedTime,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SageMakerSpace) Remove() error {
+	_, err := f.svc.DeleteSpace(&sagemaker.DeleteSpaceInput{
+		DomainId:  f.domainID,
+		SpaceName: f.spaceName,
+	})
+
+	return err
+}
+
+func (f *SageMakerSpace) String() string {
+	return *f.spaceName
+}
+
+func (i *SageMakerSpace) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("DomainID", i.domainID).
+		Set("SpaceDisplayName", i.spaceDisplayName).
+		Set("SpaceName", i.spaceName).
+		Set("Status", i.status).
+		Set("LastModifiedTime", i.lastModifiedTime)
+	return properties
+}


### PR DESCRIPTION
This change adds the deletion of SageMaker spaces, and fixes the deletion problem impacting SageMaker Apps when associated to Spaces (a SageMaker app can be associated with either a user profile or a space)

Closes #1184 
Likely closes #1004 but there is no log in the issue to be certain of the dependency problem reported
Likely closes #1216 as well.

**Output with feature activated**

```
aws-nuke version b89af78.dirty - Sat Mar  2 11:18:38 CET 2024 - b89af78ba2bbbd0e5e875c430330be0fdce7c45e

Do you really want to nuke the account with the ID 000000000000 and the alias 'nuke-me'?
Do you want to continue? Enter account alias to continue.
> nuke-me

eu-west-3 - SageMakerSpace - jupyter-dev - [DomainID: "d-xxx", LastModifiedTime: "2024-03-01 13:47:26.604 +0000 UTC", SpaceName: "jupyter-dev", Status: "InService"] - would remove
eu-west-3 - SageMakerApp - default - [AppName: "default", AppType: "JupyterLab", DomainID: "d-xxx", SpaceName: "jupyter-dev"] - would remove
eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - would remove
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - would remove
Scan complete: 4 total, 4 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID 000000000000 and the alias 'nuke-me'?
Do you want to continue? Enter account alias to continue.
> nuke-me

eu-west-3 - SageMakerSpace - jupyter-dev - [DomainID: "d-xxx", LastModifiedTime: "2024-03-01 13:47:26.604 +0000 UTC", SpaceName: "jupyter-dev", Status: "InService"] - failed
eu-west-3 - SageMakerApp - default - [AppName: "default", AppType: "JupyterLab", DomainID: "d-xxx", SpaceName: "jupyter-dev"] - triggered remove
eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - failed
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - failed

Removal requested: 1 waiting, 3 failed, 0 skipped, 0 finished

eu-west-3 - SageMakerSpace - jupyter-dev - [DomainID: "d-xxx", LastModifiedTime: "2024-03-01 13:47:26.604 +0000 UTC", SpaceName: "jupyter-dev", Status: "InService"] - waiting
eu-west-3 - SageMakerApp - default - [AppName: "default", AppType: "JupyterLab", DomainID: "d-xxx", SpaceName: "jupyter-dev"] - removed
eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - failed
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - failed

Removal requested: 1 waiting, 2 failed, 0 skipped, 1 finished

eu-west-3 - SageMakerSpace - jupyter-dev - [DomainID: "d-xxx", LastModifiedTime: "2024-03-01 13:47:26.604 +0000 UTC", SpaceName: "jupyter-dev", Status: "InService"] - removed
eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - triggered remove
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - failed

Removal requested: 1 waiting, 1 failed, 0 skipped, 2 finished

eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - waiting
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - triggered remove

Removal requested: 2 waiting, 0 failed, 0 skipped, 2 finished

eu-west-3 - SageMakerUserProfiles - default-000 - [DomainID: "d-xxx", UserProfileName: "default-000"] - removed
eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - waiting

Removal requested: 1 waiting, 0 failed, 0 skipped, 3 finished

eu-west-3 - SageMakerDomain - d-xxx - [DomainID: "d-xxx"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 4 finished

Nuke complete: 0 failed, 0 skipped, 4 finished.
```