### PR TITLE
allow nuking accounts with prod substring, if you wish

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,14 +26,15 @@ type Account struct {
 
 type Nuke struct {
 	// Deprecated: Use AccountBlocklist instead.
-	AccountBlacklist []string                     `yaml:"account-blacklist"`
-	AccountBlocklist []string                     `yaml:"account-blocklist"`
-	Regions          []string                     `yaml:"regions"`
-	Accounts         map[string]Account           `yaml:"accounts"`
-	ResourceTypes    ResourceTypes                `yaml:"resource-types"`
-	Presets          map[string]PresetDefinitions `yaml:"presets"`
-	FeatureFlags     FeatureFlags                 `yaml:"feature-flags"`
-	CustomEndpoints  CustomEndpoints              `yaml:"endpoints"`
+	AccountBlacklist             []string                     `yaml:"account-blacklist"`
+	AccountBlocklist             []string                     `yaml:"account-blocklist"`
+	Regions                      []string                     `yaml:"regions"`
+	Accounts                     map[string]Account           `yaml:"accounts"`
+	ResourceTypes                ResourceTypes                `yaml:"resource-types"`
+	Presets                      map[string]PresetDefinitions `yaml:"presets"`
+	FeatureFlags                 FeatureFlags                 `yaml:"feature-flags"`
+	CustomEndpoints              CustomEndpoints              `yaml:"endpoints"`
+	DeniedAccountAliasSubStrings []string                     `yaml:"denied_account_alias_sub_strings"`
 }
 
 type FeatureFlags struct {
@@ -136,9 +137,11 @@ func (c *Nuke) ValidateAccount(accountID string, aliases []string) error {
 	}
 
 	for _, alias := range aliases {
-		if strings.Contains(strings.ToLower(alias), "prod") {
-			return fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
-				"but it has the substring 'prod' in it. Aborting.", alias)
+		for _, subString := range c.DeniedAccountAliasSubStrings {
+			if strings.Contains(strings.ToLower(alias), subString) {
+				return fmt.Errorf("You are trying to nuke an account with the alias '%s', "+
+					"but it has the substring '%s' in it. Aborting.", alias, subString)
+			}
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,7 +52,7 @@ func TestLoadExampleConfig(t *testing.T) {
 	}
 
 	expect := Nuke{
-		AccountBlocklist: []string{"1234567890"},
+		AccountBlocklist: []string{"1234567890", "123455566", "123455577"},
 		Regions:          []string{"eu-west-1", "stratoscale"},
 		Accounts: map[string]Account{
 			"555133742": {
@@ -69,6 +69,8 @@ func TestLoadExampleConfig(t *testing.T) {
 					Targets: types.Collection{"S3Bucket"},
 				},
 			},
+			"123455588": {},
+			"123455599": {},
 		},
 		ResourceTypes: ResourceTypes{
 			Targets:  types.Collection{"DynamoDBTable", "S3Bucket", "S3Object"},
@@ -212,9 +214,20 @@ func TestConfigValidation(t *testing.T) {
 		{ID: "555133742", Aliases: []string{"staging"}, ShouldFail: false},
 		{ID: "1234567890", Aliases: []string{"staging"}, ShouldFail: true},
 		{ID: "1111111111", Aliases: []string{"staging"}, ShouldFail: true},
-		{ID: "555133742", Aliases: []string{"production"}, ShouldFail: true},
+		{ID: "555133742", Aliases: []string{"production"}, ShouldFail: false},
 		{ID: "555133742", Aliases: []string{}, ShouldFail: true},
-		{ID: "555133742", Aliases: []string{"staging", "prod"}, ShouldFail: true},
+		{ID: "555133742", Aliases: []string{"staging", "prod"}, ShouldFail: false},
+		// Production accounts in blocklist
+		{ID: "123455566", Aliases: []string{"staging", "prod"}, ShouldFail: true},
+		{ID: "123455577", Aliases: []string{"production"}, ShouldFail: true},
+		// Production accounts not in blocklist
+		{ID: "123455588", Aliases: []string{"staging", "prod"}, ShouldFail: false},
+		{ID: "123455599", Aliases: []string{"production"}, ShouldFail: false},
+		// Production account in blocklist and not added to accounts
+		{ID: "123457755", Aliases: []string{"staging", "prod"}, ShouldFail: true},
+		{ID: "123457788", Aliases: []string{"production"}, ShouldFail: true},
+		// Denied account alias substrings
+		{ID: "123432223", Aliases: []string{"some-accont-with-my-denied-sub-string-oh-yeah"}, ShouldFail: true},
 	}
 
 	for i, tc := range cases {

--- a/pkg/config/test-fixtures/example.yaml
+++ b/pkg/config/test-fixtures/example.yaml
@@ -5,6 +5,8 @@ regions:
 
 account-blocklist:
 - 1234567890
+- 123455566
+- 123455577
 
 endpoints:
 - region: stratoscale
@@ -24,6 +26,9 @@ resource-types:
   excludes:
   - IAMRole
 
+denied_account_alias_sub_strings:
+  - "my-denied-sub-string"
+
 accounts:
   555133742:
     presets:
@@ -36,6 +41,10 @@ accounts:
       - "uber.admin"
       IAMRolePolicyAttachment:
       - "uber.admin -> AdministratorAccess"
+  123455588: {}
+  123455599: {}
+  # Account that should be denied because of denied_account_alias_sub_strings
+  123432223: {}
 
 presets:
   terraform:


### PR DESCRIPTION
This program seems to have a lot of safeguards, and I felt hard coded prod substring was too restrictive/prescriptive. I updated the code to allow folks to define their own substring's they wish to block. If none, then don't add any. If `"prod"`, then add it.