### PR TITLE
Add module for dynamodb backups

### DIFF
--- a/resources/dynamodb-backups.go
+++ b/resources/dynamodb-backups.go
@@ -1,0 +1,73 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type DynamoDBBackup struct {
+	svc *dynamodb.DynamoDB
+	id  string
+}
+
+func init() {
+	register("DynamoDBBackup", ListDynamoDBBackups)
+}
+
+func ListDynamoDBBackups(sess *session.Session) ([]Resource, error) {
+	svc := dynamodb.New(sess)
+
+	resources := make([]Resource, 0)
+
+	var lastEvaluatedBackupArn *string
+
+	for {
+		backupsResp, err := svc.ListBackups(&dynamodb.ListBackupsInput{
+			ExclusiveStartBackupArn: lastEvaluatedBackupArn,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, backup := range backupsResp.BackupSummaries {
+			resources = append(resources, &DynamoDBBackup{
+				svc: svc,
+				id:  *backup.BackupArn,
+			})
+		}
+
+		if backupsResp.LastEvaluatedBackupArn == nil {
+			break
+		}
+
+		lastEvaluatedBackupArn = backupsResp.LastEvaluatedBackupArn
+	}
+
+	return resources, nil
+}
+
+func (i *DynamoDBBackup) Remove() error {
+	params := &dynamodb.DeleteBackupInput{
+		BackupArn: aws.String(i.id),
+	}
+
+	_, err := i.svc.DeleteBackup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *DynamoDBBackup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Identifier", i.id)
+
+	return properties
+}
+
+func (i *DynamoDBBackup) String() string {
+	return i.id
+}


### PR DESCRIPTION
This PR adds a new module to handle DynamoDB backups.

## Testing steps

- Create dynamodb table and a backup:

```
# create a table
aws dynamodb create-table \
    --table-name Music \
    --attribute-definitions \
        AttributeName=Artist,AttributeType=S \
        AttributeName=SongTitle,AttributeType=S \
    --key-schema \
        AttributeName=Artist,KeyType=HASH \
        AttributeName=SongTitle,KeyType=RANGE \
    --provisioned-throughput \
        ReadCapacityUnits=5,WriteCapacityUnits=5 \
    --table-class STANDARD

# Create backup
aws dynamodb create-backup --table-name Music --backup-name Music_backup
```
- Run aws-nuke including `DynamoDBBackup` module
- Verify if resources were cleaned up successfully

```
# List backups
aws dynamodb list-backups
```