### PR TITLE
feat(pkg/config/filter): only warn on date parse error

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -221,7 +221,7 @@ func (n *Nuke) Filter(item *Item) error {
 			logrus.Warnf(err.Error())
 			continue
 		}
-		match, err := filter.Match(prop)
+		match, err := filter.Match(prop, n.Config)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type FeatureFlags struct {
 	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	DisableEC2InstanceStopProtection bool                      `yaml:"disable-ec2-instance-stop-protection"`
 	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
+	NukeOnDateParseError             bool                      `yaml:"nuke-on-date-parse-error"`
 }
 
 type DisableDeletionProtection struct {

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -37,7 +37,7 @@ type Filter struct {
 	Invert   string
 }
 
-func (f Filter) Match(o string) (bool, error) {
+func (f Filter) Match(o string, c *Nuke) (bool, error) {
 	switch f.Type {
 	case FilterTypeEmpty:
 		fallthrough
@@ -64,13 +64,21 @@ func (f Filter) Match(o string) (bool, error) {
 		}
 		duration, err := time.ParseDuration(f.Value)
 		if err != nil {
-			log.Warnf("Failed to parse duration %s: %s", o, err)
-			return false, nil
+			if c.FeatureFlags.NukeOnDateParseError {
+				log.Warnf("Failed to parse duration %s: %s", o, err)
+				return false, nil
+			} else {
+				return false, err
+			}
 		}
 		fieldTime, err := parseDate(o)
 		if err != nil {
-			log.Warnf("Failed to parse date %s: %s", o, err)
-			return false, nil
+			if c.FeatureFlags.NukeOnDateParseError {
+				log.Warnf("Failed to parse date %s: %s", o, err)
+				return false, nil
+			} else {
+				return false, err
+			}
 		}
 		fieldTimeWithOffset := fieldTime.Add(duration)
 

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mb0/glob"
+	log "github.com/sirupsen/logrus"
 )
 
 type FilterType string
@@ -63,11 +64,13 @@ func (f Filter) Match(o string) (bool, error) {
 		}
 		duration, err := time.ParseDuration(f.Value)
 		if err != nil {
-			return false, err
+			log.Warnf("Failed to parse duration %s: %s", o, err)
+			return false, nil
 		}
 		fieldTime, err := parseDate(o)
 		if err != nil {
-			return false, err
+			log.Warnf("Failed to parse date %s: %s", o, err)
+			return false, nil
 		}
 		fieldTimeWithOffset := fieldTime.Add(duration)
 


### PR DESCRIPTION
In current state when you use a `dateOlderThan` filter, it'll return an error if it comes across a resource/field that it cannot parse as a date, and will prevent `aws-nuke` from running on all of the other resources it may have successfully processed

This change will instead only log a warning when an error occurs, which the user will be able to see. The resource will not be filtered out (although I'm not opinionated either way, my main goal is to not hold up `aws-nuke` from running because one resource was misconfigured)

I'm open to feedback/change requests

Here's an example output with these changes:
```
Do you really want to nuke the account with the ID 123456789012 and the alias 'my-account'?
Waiting 3s before continuing.
time="2024-07-11T21:22:47Z" level=warning msg="Failed to parse date IAMNOTADATE: unable to parse time IAMNOTADATE"
us-west-1 - DynamoDBTable - testing - [Identifier: "testing", tag:expiration-date: "IAMNOTADATE"] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

The above resources would be deleted with the supplied configuration. Provide --no-dry-run to actually destroy resources.
```