### PR TITLE
Adding Athena data catalogs and prepared statements

### DIFF
--- a/resources/athena-data-catalogs.go
+++ b/resources/athena-data-catalogs.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type AthenaDataCatalog struct {
+	svc  *athena.Athena
+	name *string
+}
+
+func init() {
+	register("AthenaDataCatalog", ListAthenaDataCatalogs)
+}
+
+func ListAthenaDataCatalogs(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	params := &athena.ListDataCatalogsInput{
+		MaxResults: aws.Int64(50),
+	}
+
+	for {
+		output, err := svc.ListDataCatalogs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, catalog := range output.DataCatalogsSummary {
+			resources = append(resources, &AthenaDataCatalog{
+				svc:  svc,
+				name: catalog.CatalogName,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *AthenaDataCatalog) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", f.name)
+
+	return properties
+}
+
+func (f *AthenaDataCatalog) Remove() error {
+
+	_, err := f.svc.DeleteDataCatalog(&athena.DeleteDataCatalogInput{
+		Name: f.name,
+	})
+
+	return err
+}
+
+func (f *AthenaDataCatalog) Filter() error {
+	if *f.name == "AwsDataCatalog" {
+		return fmt.Errorf("cannot delete default data source")
+	}
+	return nil
+}
+
+func (f *AthenaDataCatalog) String() string {
+	return *f.name
+}

--- a/resources/athena-prepared-statements.go
+++ b/resources/athena-prepared-statements.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type AthenaPreparedStatement struct {
+	svc       *athena.Athena
+	workGroup *string
+	name      *string
+}
+
+func init() {
+	register("AthenaPreparedStatement", ListAthenaPreparedStatements)
+}
+
+func ListAthenaPreparedStatements(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	workgroups, err := svc.ListWorkGroups(&athena.ListWorkGroupsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, workgroup := range workgroups.WorkGroups {
+		params := &athena.ListPreparedStatementsInput{
+			WorkGroup:  workgroup.Name,
+			MaxResults: aws.Int64(50),
+		}
+
+		for {
+			output, err := svc.ListPreparedStatements(params)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, statement := range output.PreparedStatements {
+				resources = append(resources, &AthenaPreparedStatement{
+					svc:       svc,
+					workGroup: workgroup.Name,
+					name:      statement.StatementName,
+				})
+			}
+
+			if output.NextToken == nil {
+				break
+			}
+
+			params.NextToken = output.NextToken
+		}
+	}
+
+	return resources, nil
+}
+
+func (f *AthenaPreparedStatement) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("StatementName", f.name)
+	properties.Set("WorkGroup", f.workGroup)
+
+	return properties
+}
+
+func (f *AthenaPreparedStatement) Remove() error {
+
+	_, err := f.svc.DeletePreparedStatement(&athena.DeletePreparedStatementInput{
+		StatementName: f.name,
+		WorkGroup:     f.workGroup,
+	})
+
+	return err
+}
+
+func (f *AthenaPreparedStatement) String() string {
+	return *f.name
+}


### PR DESCRIPTION
This PR adds support for AWS Athena data catalogs and prepared statements.

### Testing

Athena resources were created using the following script with these resources add to the config file:
`AthenaDataCatalog`
`AthenaNamedQuery`
`AthenaPreparedStatement`
`AthenaWorkGroup`

```
# Generate a random string to use as a bucket name and classifier name suffix
RANDOM_STRING=$(openssl rand -hex 20)
# Generate a random string for shorter names
SHORT_RANDOM_STRING=$(openssl rand -hex 10)

# Set your preferred bucket names
INPUT_BUCKET="input-bucket-$RANDOM_STRING"

# Get AWS account ID
AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
echo "AWS Account ID: $AWS_ACCOUNT_ID"

# Create input bucket
aws s3api create-bucket --bucket $INPUT_BUCKET
echo "Input bucket created: s3://$INPUT_BUCKET"

# Create a KMS key
KMS_KEY_ARN=$(aws kms create-key --query 'KeyMetadata.Arn' --output text)
echo "KMS key created: $KMS_KEY_ARN"

# Extract the key ID from the ARN
KMS_KEY_ID=$(basename "$KMS_KEY_ARN" | cut -d '/' -f 2)
echo "KMS key ID: $KMS_KEY_ID"

# Set encryption settings for the Data Catalog
aws glue put-data-catalog-encryption-settings \
    --data-catalog-encryption-settings '{
        "EncryptionAtRest": {
            "CatalogEncryptionMode": "SSE-KMS",
            "SseAwsKmsKeyId": "'"$KMS_KEY_ID"'"
        }
    }'
echo "Data Catalog encryption settings set"

# Create the database if it doesn't exist
aws glue create-database --database-input '{"Name": "my_database"}'
echo "Database created"

# Create a data catalog table
aws glue create-table --database-name my_database --table-input '{
    "Name": "my_table",
    "Description": "My Glue Data Catalog table",
    "PartitionKeys": [
        {
            "Name": "partition_column",
            "Type": "string"
        }
    ],
    "StorageDescriptor": {
        "Columns": [
            {
                "Name": "column1",
                "Type": "string"
            },
            {
                "Name": "column2",
                "Type": "int"
            }
        ],
        "Location": "s3://'$INPUT_BUCKET'/data/",
        "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
        "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
        "Compressed": false,
        "SerdeInfo": {
            "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
            "Parameters": {
                "field.delim": ","
            }
        }
    }
}'
echo "Data catalog table created"

# Create a data catalog classifier
aws athena create-data-catalog \
    --name "athena-data-catalog" \
    --type GLUE \
    --parameters catalog-id=$AWS_ACCOUNT_ID
echo "Data catalog classifier created"

# Create a named query in Athena
aws athena create-named-query \
    --name "athena-test-query" \
    --database "my_database" \
    --query-string "SELECT * FROM my_table"
echo "Named query created"


# Create Athena_DefaultRole if it doesn't exist
aws iam create-role --role-name Athena_DefaultRole --assume-role-policy-document '{
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Principal": {
            "Service": "athena.amazonaws.com"
        },
        "Action": "sts:AssumeRole"
    }]
}'
echo "Athena_DefaultRole created"

# Attach custom policy to Athena_DefaultRole
aws iam put-role-policy \
    --role-name Athena_DefaultRole \
    --policy-name AthenaFullAccessPolicy \
    --policy-document '{
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Action": [
                    "athena:*"
                ],
                "Resource": "*"
            }
        ]
    }'
echo "Custom policy attached to Athena_DefaultRole"

# Construct the correct IAM role ARN
ATHENA_DEFAULT_ROLE_ARN="arn:aws:iam::$AWS_ACCOUNT_ID:role/Athena_DefaultRole"
echo "Athena Default Role ARN: $ATHENA_DEFAULT_ROLE_ARN"

# Create an athena workgroup
aws athena create-work-group \
    --name "my_workgroup" \
    --configuration '{
        "ResultConfiguration": {
            "OutputLocation": "s3://'$INPUT_BUCKET'/query-results/",
            "EncryptionConfiguration": {
                "EncryptionOption": "SSE_S3"
            }
        },
        "EnforceWorkGroupConfiguration": true,
        "EngineVersion": {
            "SelectedEngineVersion": "PySpark engine version 3"
        },
        "ExecutionRole": "'"$ATHENA_DEFAULT_ROLE_ARN"'"
    }'
echo "Athena workgroup created"


# Create an athena notebook
aws athena create-notebook \
    --work-group "my_workgroup" \
    --name "my_athena_notebook"
echo "Athena notebook created"

# Create a prepared statement in Athena
aws athena create-prepared-statement \
    --statement-name "my_prepared_statement" \
    --work-group "primary" \
    --query-statement "SELECT * FROM my_table WHERE created_at > CAST(? AS date) LIMIT 10"
echo "Prepared statement created"

# List data catalogs
aws athena list-data-catalogs

# List athena named queries
aws athena list-named-queries

# List athena workgroups
aws athena list-work-groups

# List athena notebooks metadata
aws athena list-notebook-metadata --work-group "my_workgroup"

# List prepared statement
aws athena list-prepared-statements --work-group "primary"
```
