### PR TITLE
Adding elastictranscoder preset support.

### DIFF
--- a/resources/elastictranscoder-preset.go
+++ b/resources/elastictranscoder-preset.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elastictranscoder"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type ElasticTranscoderPreset struct {
+	svc      *elastictranscoder.ElasticTranscoder
+	presetID *string
+}
+
+func init() {
+	register("ElasticTranscoderPreset", ListElasticTranscoderPresets)
+}
+
+func ListElasticTranscoderPresets(sess *session.Session) ([]Resource, error) {
+	svc := elastictranscoder.New(sess)
+	resources := []Resource{}
+
+	params := &elastictranscoder.ListPresetsInput{}
+
+	for {
+		resp, err := svc.ListPresets(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, preset := range resp.Presets {
+			resources = append(resources, &ElasticTranscoderPreset{
+				svc:      svc,
+				presetID: preset.Id,
+			})
+		}
+
+		if resp.NextPageToken == nil {
+			break
+		}
+
+		params.PageToken = resp.NextPageToken
+	}
+
+	return resources, nil
+}
+
+func (f *ElasticTranscoderPreset) Filter() error {
+	if strings.HasPrefix(*f.presetID, "1351620000001") {
+		return fmt.Errorf("cannot delete elastic transcoder system presets")
+	}
+	return nil
+}
+
+func (f *ElasticTranscoderPreset) Remove() error {
+
+	_, err := f.svc.DeletePreset(&elastictranscoder.DeletePresetInput{
+		Id: f.presetID,
+	})
+
+	return err
+}
+
+func (f *ElasticTranscoderPreset) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("PresetID", f.presetID)
+	return properties
+}
+
+func (f *ElasticTranscoderPreset) String() string {
+	return *f.presetID
+}


### PR DESCRIPTION
This PR adds support for ElasticTranscoder Preset Support.

### Testing
The following resources types were added to the config file:
"ElasticTranscoderPipeline"
"ElasticTranscoderPreset"

Resources were created for testing using this script:
```
# Generate a random string to use as a bucket name and classifier name suffix
RANDOM_STRING=$(openssl rand -hex 20)
# Generate a random string for shorter names
SHORT_RANDOM_STRING=$(openssl rand -hex 10)

# Get AWS account ID
AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
echo "AWS Account ID: $AWS_ACCOUNT_ID"

# Set your preferred bucket names
INPUT_BUCKET="input-bucket-$SHORT_RANDOM_STRING"
OUTPUT_BUCKET="output-bucket-$SHORT_RANDOM_STRING"

# Create input bucket
aws s3api create-bucket --bucket $INPUT_BUCKET --no-cli-pager
echo "Input bucket created: s3://$INPUT_BUCKET"

# Create output bucket
aws s3api create-bucket --bucket $OUTPUT_BUCKET --no-cli-pager
echo "Output bucket created: s3://$OUTPUT_BUCKET"

# Define the role name
ROLE_NAME="elastictranscoder-access-role-$SHORT_RANDOM_STRING"

# Create the IAM role
aws iam create-role \
  --role-name $ROLE_NAME \
  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"elastictranscoder.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
echo "IAM role created: $ROLE_NAME"

# Attach the necessary policy to the role
aws iam attach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonElasticTranscoder_FullAccess
echo "Policy attached to role"

# Create elastic transcoder pipeline
PIPELINE_RESPONSE=$(aws elastictranscoder create-pipeline \
  --name "my-et-pipeline" \
  --input-bucket "$INPUT_BUCKET" \
  --output-bucket "$OUTPUT_BUCKET" \
  --role "arn:aws:iam::$AWS_ACCOUNT_ID:role/$ROLE_NAME" \
  --output json)

# Extract the pipeline ID from the response
PIPELINE_ID=$(echo $PIPELINE_RESPONSE | jq -r '.Pipeline.Id')
echo "Pipeline ID: $PIPELINE_ID"

# Create an example elastic transcoder preset
PRESET_RESPONSE=$(aws elastictranscoder create-preset \
  --name "my-et-preset" \
  --description "Description of my preset" \
  --container "mp3" \
  --audio "Codec=mp3,SampleRate=44100,BitRate=64,Channels=2")

# Extract the preset ID from the response
PRESET_ID=$(echo $PRESET_RESPONSE | jq -r '.Preset.Id')
echo "Elastic transcoder preset created with ID: $PRESET_ID"

# Create an example elastic transcoder job
aws elastictranscoder create-job \
  --pipeline-id "$PIPELINE_ID" \
  --inputs "Key=files/MLKDreamSpeech.mp3" \
  --outputs "Key=output_file.json,PresetId=$PRESET_ID"
echo "Elastic transcoder job created"

# # List elastic transcoder pipelines
# aws elastictranscoder list-pipelines --no-cli-pager

# # List elastic transcoder presets
# aws elastictranscoder list-presets --no-cli-pager

# # List elastic transcoder jobs
# aws elastictranscoder list-jobs-by-pipeline --pipeline-id "$PIPELINE_ID" --no-cli-pager
```